### PR TITLE
added precision test

### DIFF
--- a/surprise/accuracy.py
+++ b/surprise/accuracy.py
@@ -10,6 +10,7 @@ Available accuracy metrics:
     rmse
     mae
     fcp
+    prec
 """
 
 from __future__ import (absolute_import, division, print_function,
@@ -141,3 +142,40 @@ def fcp(predictions, verbose=True):
         print('FCP:  {0:1.4f}'.format(fcp))
 
     return fcp
+
+
+def prec(predictions, verbose=True):
+    """Compute the precision of a binary rating predictor.
+
+    Precision <https://en.wikipedia.org/wiki/Information_retrieval#Precision>
+    (also known as positive predictive value) is defined as the fraction of
+    test-positives that are also true-positives. This method only works when
+    the ratings are all either 0 or 1.
+
+    Args:
+        predictions (:obj:`list` of :obj:`Prediction\
+            <surprise.prediction_algorithms.predictions.Prediction>`):
+            A list of predictions, as returned by the :meth:`test()
+            <surprise.prediction_algorithms.algo_base.AlgoBase.test>` method.
+        verbose: If True, will print computed value. Default is ``True``.
+
+    Returns:
+        The precision
+
+    Raises:
+        ValueError: When ``predictions`` is empty.
+    """
+
+    if not predictions:
+        raise ValueError('Prediction list is empty.')
+
+    true_pos = np.sum([est == 1 and true_r == 1
+                       for (_, _, true_r, est, _) in predictions])
+    marked_pos = np.sum([est == 1
+                         for (_, _, _, est, _) in predictions])
+    prec = true_pos / marked_pos
+
+    if verbose:
+        print('PREC: {:1.4f}'.format(prec))
+
+    return prec

--- a/surprise/accuracy.py
+++ b/surprise/accuracy.py
@@ -169,11 +169,17 @@ def prec(predictions, verbose=True):
     if not predictions:
         raise ValueError('Prediction list is empty.')
 
-    true_pos = np.sum([est == 1 and true_r == 1
+    true_pos = np.sum([est > 0.5 and true_r == 1
                        for (_, _, true_r, est, _) in predictions])
-    marked_pos = np.sum([est == 1
+    marked_pos = np.sum([est > 0.5
                          for (_, _, _, est, _) in predictions])
-    prec = true_pos / marked_pos
+
+
+    try:
+        prec = true_pos / marked_pos
+    except ZeroDivisionError:
+        raise ValueError('Cannot compute precision because estimator gave no' +
+                         'positive results')
 
     if verbose:
         print('PREC: {:1.4f}'.format(prec))

--- a/tests/test_accuracy.py
+++ b/tests/test_accuracy.py
@@ -6,7 +6,7 @@ from math import sqrt
 
 import pytest
 
-from surprise.accuracy import mae, rmse, fcp
+from surprise.accuracy import mae, rmse, fcp, prec
 
 
 def pred(true_r, est, u0=None):
@@ -67,3 +67,16 @@ def test_fcp():
 
     with pytest.raises(ValueError):
         fcp([])
+
+
+def test_prec():
+    """Tests for the prec function."""
+
+    predictions = [pred(0, 0), pred(1, 1), pred(0, 0), pred(1, 0)]
+    assert prec(predictions) == 1
+
+    predictions = [pred(0, 0), pred(1, 1), pred(0, 0), pred(0, 1)]
+    assert prec(predictions) == 1/2
+
+    with pytest.raises(ValueError):
+        prec([])


### PR DESCRIPTION
Some recommendations are made based on data that is boolean (user bought this or user didn't buy this) instead of k-class ratings. In this case, it could make sense to use[precision](https://en.wikipedia.org/wiki/Precision_and_recall) as the evaluation metric. In that case, you would be maximizing the probability that you recommend something that the user would want to buy.