### PR TITLE
Add precision and recall at k example in the FAQ

### DIFF
--- a/doc/source/FAQ.rst
+++ b/doc/source/FAQ.rst
@@ -20,6 +20,23 @@ top-10 prediction for each user.
     :name: top_n_recommendations.py
     :lines: 10-
 
+.. _precision_recall_at_k:
+
+How to evaluate an algorithm using precision and recall at k metrics
+-----------------------------------------------------------------------
+
+Below is an example on how to compute Precision@k and Recall@k metrics for
+a recommendation model. We first split our dataset into train and test 
+folds. Using cross validation and on each iteration we train on our trainset 
+and get the predictions from the testset. Finally we compute Precision@k 
+and Recall@k for the predictions.
+
+
+.. literalinclude:: ../../examples/precision_recall_at_k.py
+    :caption: From file ``examples/precision_recall_at_k.py``
+    :name: precision_recall_at_k.py
+    :lines: 10-
+
 .. _get_k_nearest_neighbors:
 
 How to get the k nearest neighbors of a user (or item)

--- a/doc/source/FAQ.rst
+++ b/doc/source/FAQ.rst
@@ -22,20 +22,26 @@ top-10 prediction for each user.
 
 .. _precision_recall_at_k:
 
-How to evaluate an algorithm using precision and recall at k metrics
+How to compute precision@k and recall@k
 -----------------------------------------------------------------------
 
 Below is an example on how to compute Precision@k and Recall@k metrics for
 a recommendation model. We first split our dataset into train and test 
 folds. Using cross validation and on each iteration we train on our trainset 
 and get the predictions from the testset. Finally we compute Precision@k 
-and Recall@k for each user in predictions.
+and Recall@k for each user:
 
+* :math:`Precision@k = \frac{ | \{ \text{Recommended items that are relevant} \} | }{ | \{ \text{Recommended items} \} | }`
+* :math:`Recall@k = \frac{ | \{ \text{Recommended items that are relevant} \} | }{ | \{ \text{Relevant items} \} | }`
+
+An item is considered relevant if its rating is greater than the user defined threshold.
+An item is considered recommended if its estimated rating is greater than the
+user defined threshold, and if it is among the k highest estimated ratings.
 
 .. literalinclude:: ../../examples/precision_recall_at_k.py
     :caption: From file ``examples/precision_recall_at_k.py``
     :name: precision_recall_at_k.py
-    :lines: 11-
+    :lines: 7-
 
 .. _get_k_nearest_neighbors:
 

--- a/doc/source/FAQ.rst
+++ b/doc/source/FAQ.rst
@@ -29,7 +29,7 @@ Below is an example on how to compute Precision@k and Recall@k metrics for
 a recommendation model. We first split our dataset into train and test 
 folds. Using cross validation and on each iteration we train on our trainset 
 and get the predictions from the testset. Finally we compute Precision@k 
-and Recall@k for the predictions.
+and Recall@k for each user in predictions.
 
 
 .. literalinclude:: ../../examples/precision_recall_at_k.py

--- a/doc/source/FAQ.rst
+++ b/doc/source/FAQ.rst
@@ -35,7 +35,7 @@ and Recall@k for each user in predictions.
 .. literalinclude:: ../../examples/precision_recall_at_k.py
     :caption: From file ``examples/precision_recall_at_k.py``
     :name: precision_recall_at_k.py
-    :lines: 10-
+    :lines: 11-
 
 .. _get_k_nearest_neighbors:
 

--- a/examples/precision_recall_at_k.py
+++ b/examples/precision_recall_at_k.py
@@ -14,10 +14,10 @@ def precision_recall_at_k(predictions, k=10, threshold=3.5, verbose=True):
     Args:
         predictions(list of Prediction objects): The list of predictions, as
             returned by the test method of an algorithm.
-        k(int): The number of recommendations for which precision and recall
+        k(int): The number of recommendations on which precision and recall
             will be computed. Default is 10.
-        threshold(float): A value after which ratings are considered positive.
-            Default is 3.5
+        threshold(float): All rating greater than or equal to threshold are
+            considered positive. Default is 3.5
     Returns:
     A tuple with the value (Precision@k, Recall@k)
     '''
@@ -50,11 +50,12 @@ def precision_recall_at_k(predictions, k=10, threshold=3.5, verbose=True):
 
 
 def user_precision_recall(top_preds, threshold):
-    '''Return mean precision and recall for a specific user.
+    '''Return precision and recall for predictions.
 
     Args:
         top_preds(numpy 2d array): An array of [iid, est, true_r]
-        threshold(float): A value after which ratings are considered positive.
+        threshold(float): All rating greater than or equal to threshold are
+            considered positive. Default is 3.5
 
     Returns:
     A tuple with the value (Precision, Recall)

--- a/examples/precision_recall_at_k.py
+++ b/examples/precision_recall_at_k.py
@@ -42,15 +42,20 @@ def precision_recall_at_k(predictions, k=10, threshold=3.5, verbose=True):
         # Sort list by estimated rating
         user_ratings.sort(key=lambda x: x[0], reverse=True)
 
-        # Count number of relevant items in the top-k predictions
-        n_rel_at_k = sum(
-            (true_r >= threshold) for (_, true_r) in user_ratings[:k])
+        # Count number of relevant items recommended in top k
+        n_rel_and_rec_k = sum(
+            ((true_r >= threshold) and (est >= threshold)) for (
+                est, true_r) in user_ratings[:k])
+
+        # Count number of recommended items in top k
+        n_rec_k = sum(
+            (est >= threshold) for (est, _) in user_ratings[:k])
 
         # Precision@K: Proportion of top-k documents that are relevant
-        precision_at_k = n_rel_at_k / k
+        precision_at_k = n_rel_and_rec_k / n_rec_k if n_rec_k != 0 else 1
 
         # Recall@K: Proportion of relevant items that are in the top-k
-        recall_at_k = n_rel_at_k / n_rel if n_rel != 0 else 1
+        recall_at_k = n_rel_and_rec_k / n_rel if n_rel != 0 else 1
 
         precision_recall_k[uid] = (precision_at_k, recall_at_k)
 

--- a/examples/precision_recall_at_k.py
+++ b/examples/precision_recall_at_k.py
@@ -2,14 +2,13 @@ from __future__ import (absolute_import, division, print_function,
                         unicode_literals)
 
 from collections import defaultdict
-import numpy as np
 
 from surprise import Dataset
-from surprise import BaselineOnly
+from surprise import SVD
 
 
 def precision_recall_at_k(predictions, k=10, threshold=3.5, verbose=True):
-    '''Return mean precision and recall at k for all users.
+    '''Return Precision and recall at K metrics for each user.
 
     Args:
         predictions(list of Prediction objects): The list of predictions, as
@@ -19,112 +18,45 @@ def precision_recall_at_k(predictions, k=10, threshold=3.5, verbose=True):
         threshold(float): All rating greater than or equal to threshold are
             considered positive. Default is 3.5
     Returns:
-    A tuple with the value (Precision@k, Recall@k)
+    A dict where keys are user (raw) ids and values are tuples
+        (precision@k, recall@k).
     '''
+
     # First map the predictions to each user.
     top_n = defaultdict(list)
-    precision_recall_k =  defaultdict(list)
+    precision_recall_k = defaultdict(tuple)
     for uid, iid, true_r, est, _ in predictions:
         top_n[uid].append((iid, est, true_r))
 
     # Then sort the predictions for each user and retrieve the k highest ones.
     for uid, user_ratings in top_n.items():
         user_ratings.sort(key=lambda x: x[1], reverse=True)
-        # TODO: Count number of relevant items n_rel
-        user_ratings_true_r = [x[2] for x in user_ratings]
-        n_rel = len([i for i in user_ratings_true_r if i >= threshold])
 
-        top_n[uid] = user_ratings[:k]
-        # TODO: Count number of relevant items n_rel_at_k
-        user_ratings_at_k_true_r = [x[2] for x in user_ratings[:k]]
-        n_rel_at_k = len([i for i in user_ratings_at_k_true_r if i >= threshold])
-        # TODO: Calculate precision as n_rel_rec / k
-        precision_at_k = float(n_rel_at_k)/k 
-        # TODO: Calculate recall as n_rel_rec / n_rel
+        # Count number of all relevant items
+        true_r_list = [x[2] for x in user_ratings]
+        n_rel = len([i for i in true_r_list if i >= threshold])
+
+        # Count number of relevant items in the top-k predictions
+        true_r_list_k = [x[2] for x in user_ratings[:k]]
+        n_rel_at_k = len([i for i in true_r_list_k if i >= threshold])
+
+        # Precision@K: Proportion of top-k documents that are relevant
+        precision_at_k = float(n_rel_at_k)/k
+
+        # Recall@K: Proportion of relevant items that are in the top-k
         recall_at_k = float(n_rel_at_k)/n_rel if n_rel != 0 else 1
-        # TODO: append to the dict an item with values
-        precision_recall_k[uid].append((precision_at_k,recall_at_k))
-        # TODO: return dict
+
+        precision_recall_k[uid] = (precision_at_k, recall_at_k)
+
     return precision_recall_k
-    # return top_n
-    # # First map the predictions to each user.
-    # top_n = defaultdict(list)
-    # for uid, iid, true_r, est, _ in predictions:
-    #     top_n[uid].append([iid, est, true_r])
-
-    # # Create empty array to hold precisions and recalls for all users
-    # precisions = []
-    # recalls = []
-
-    # # Then sort the predictions for each user and retrieve the k highest ones.
-    # for uid, user_ratings_array in top_n.items():
-    #     user_ratings_array = np.array(user_ratings_array)
-    #     user_ratings_array_sorted = (
-    #             user_ratings_array[user_ratings_array[:, 1].argsort()[::-1]])
-
-    #     top_k_items = user_ratings_array_sorted[:k]
-
-    #     user_precision, user_recall = user_precision_recall(
-    #         top_k_items, threshold)
-    #     precisions.append(user_precision)
-    #     recalls.append(user_recall)
-    # if verbose:
-    #     print(('Precision at %d is %1.4f') % (k, np.mean(precisions)))
-    #     print(('Recall at %d is %1.4f') % (k, np.mean(recalls)))
-    # return (np.mean(precisions), np.mean(recalls))
 
 
-def user_precision_recall(top_preds, threshold):
-    '''Return precision and recall for predictions.
+data = Dataset.load_builtin('ml-100k')
 
-    Args:
-        top_preds(numpy 2d array): An array of [iid, est, true_r]
-        threshold(float): All rating greater than or equal to threshold are
-            considered positive. Default is 3.5
+data.split(n_folds=5)
+algo = SVD()
 
-    Returns:
-    A tuple with the value (Precision, Recall)
-    '''
-
-    # Count the number of relevant, recommended and
-    # (relevant and recommended) items
-    is_relevant = np.greater_equal(top_preds[:, 2].astype(float), threshold)
-    is_recommended = np.greater_equal(top_preds[:, 1].astype(float), threshold)
-    is_relevant_and_recommended = np.logical_and(is_relevant, is_recommended)
-    n_rel = np.sum(is_relevant)
-    n_rec = np.sum(is_recommended)
-    n_rel_and_rec = np.sum(is_relevant_and_recommended)
-
-    # We do not have any false positive (Recommended AND (Not relevant))
-    precision = float(n_rel_and_rec) / n_rec if n_rec != 0 else 1
-
-    # We do not have any false negative ((Not recommended) AND (relevant))
-    recall = float(n_rel_and_rec) / n_rel if n_rel != 0 else 1
-    return(precision, recall)
-
-
-# # First train an SVD algorithm on the movielens dataset.
-# data = Dataset.load_builtin('ml-100k')
-
-# data.split(n_folds=5)
-# algo = BaselineOnly()
-
-# for trainset, testset in data.folds():
-#     algo.train(trainset)
-#     predictions = algo.test(testset)
-#     print(precision_recall_at_k(predictions, k=5, threshold=4))
-
-def pred(true_r, est, u0=None):
-    """Just a small tool to build a prediction with appropriate format."""
-    return (u0, None, true_r, est, None)
-
-predictions = [pred(4, 4.99, u0='u1'), pred(3, 4.98, u0='u1'), pred(4, 4.97, u0='u1'), pred(4, 4.96,
-               u0='u1'), pred(4, 4.95, u0='u1'), pred(4, 4.94, u0='u1'), pred(4, 4.93, u0='u1'), pred(3, 4.92,
-               u0='u1'), pred(4, 4.91, u0='u1'), pred(3, 4.90, u0='u1'), pred(4, 4.89, u0='u1'), pred(3, 4.88,
-               u0='u1'), pred(3, 4.87, u0='u1'), pred(4, 4.86, u0='u1'), pred(3, 4.85, u0='u1'), pred(3, 4.84,
-               u0='u1'), pred(3, 4.83, u0='u1'), pred(3, 4.82, u0='u1'), pred(3, 4.81, u0='u1'), pred(4, 4.80,
-               u0='u1'), pred(4, 4.79, u0='u1'), pred(4, 4.78, u0='u1'), pred(4, 4.77, u0='u1'), pred(4, 4.76,
-               u0='u1'), pred(4, 4.75, u0='u1'), pred(4, 4.74, u0='u1'), pred(4, 4.73, u0='u1'), pred(4, 4.72,
-               u0='u1'), pred(4, 4.71, u0='u1'), pred(4, 4.70, u0='u1')]
-for i in range(1,11):
-    print(precision_recall_at_k(predictions, k=i, threshold=4))
+for trainset, testset in data.folds():
+    algo.train(trainset)
+    predictions = algo.test(testset)
+    precision_recall_at_k(predictions, k=5, threshold=4)

--- a/examples/precision_recall_at_k.py
+++ b/examples/precision_recall_at_k.py
@@ -5,7 +5,7 @@ from collections import defaultdict
 import numpy as np
 
 from surprise import Dataset
-from surprise import SVD
+from surprise import BaselineOnly
 
 
 def precision_recall_at_k(predictions, k=10, threshold=3.5, verbose=True):
@@ -21,32 +21,57 @@ def precision_recall_at_k(predictions, k=10, threshold=3.5, verbose=True):
     Returns:
     A tuple with the value (Precision@k, Recall@k)
     '''
-
     # First map the predictions to each user.
     top_n = defaultdict(list)
+    precision_recall_k =  defaultdict(list)
     for uid, iid, true_r, est, _ in predictions:
-        top_n[uid].append([iid, est, true_r])
-
-    # Create empty array to hold precisions and recalls for all users
-    precisions = []
-    recalls = []
+        top_n[uid].append((iid, est, true_r))
 
     # Then sort the predictions for each user and retrieve the k highest ones.
-    for uid, user_ratings_array in top_n.items():
-        user_ratings_array = np.array(user_ratings_array)
-        user_ratings_array_sorted = (
-                user_ratings_array[user_ratings_array[:, 1].argsort()[::-1]])
+    for uid, user_ratings in top_n.items():
+        user_ratings.sort(key=lambda x: x[1], reverse=True)
+        # TODO: Count number of relevant items n_rel
+        user_ratings_true_r = [x[2] for x in user_ratings]
+        n_rel = len([i for i in user_ratings_true_r if i >= threshold])
 
-        top_k_items = user_ratings_array_sorted[:k]
+        top_n[uid] = user_ratings[:k]
+        # TODO: Count number of relevant items n_rel_at_k
+        user_ratings_at_k_true_r = [x[2] for x in user_ratings[:k]]
+        n_rel_at_k = len([i for i in user_ratings_at_k_true_r if i >= threshold])
+        # TODO: Calculate precision as n_rel_rec / k
+        precision_at_k = float(n_rel_at_k)/k 
+        # TODO: Calculate recall as n_rel_rec / n_rel
+        recall_at_k = float(n_rel_at_k)/n_rel if n_rel != 0 else 1
+        # TODO: append to the dict an item with values
+        precision_recall_k[uid].append((precision_at_k,recall_at_k))
+        # TODO: return dict
+    return precision_recall_k
+    # return top_n
+    # # First map the predictions to each user.
+    # top_n = defaultdict(list)
+    # for uid, iid, true_r, est, _ in predictions:
+    #     top_n[uid].append([iid, est, true_r])
 
-        user_precision, user_recall = user_precision_recall(
-            top_k_items, threshold)
-        precisions.append(user_precision)
-        recalls.append(user_recall)
-    if verbose:
-        print(('Precision at %d is %1.4f') % (k, np.mean(precisions)))
-        print(('Recall at %d is %1.4f') % (k, np.mean(recalls)))
-    return (np.mean(precisions), np.mean(recalls))
+    # # Create empty array to hold precisions and recalls for all users
+    # precisions = []
+    # recalls = []
+
+    # # Then sort the predictions for each user and retrieve the k highest ones.
+    # for uid, user_ratings_array in top_n.items():
+    #     user_ratings_array = np.array(user_ratings_array)
+    #     user_ratings_array_sorted = (
+    #             user_ratings_array[user_ratings_array[:, 1].argsort()[::-1]])
+
+    #     top_k_items = user_ratings_array_sorted[:k]
+
+    #     user_precision, user_recall = user_precision_recall(
+    #         top_k_items, threshold)
+    #     precisions.append(user_precision)
+    #     recalls.append(user_recall)
+    # if verbose:
+    #     print(('Precision at %d is %1.4f') % (k, np.mean(precisions)))
+    #     print(('Recall at %d is %1.4f') % (k, np.mean(recalls)))
+    # return (np.mean(precisions), np.mean(recalls))
 
 
 def user_precision_recall(top_preds, threshold):
@@ -78,13 +103,28 @@ def user_precision_recall(top_preds, threshold):
     return(precision, recall)
 
 
-# First train an SVD algorithm on the movielens dataset.
-data = Dataset.load_builtin('ml-100k')
+# # First train an SVD algorithm on the movielens dataset.
+# data = Dataset.load_builtin('ml-100k')
 
-data.split(n_folds=5)
-algo = SVD()
+# data.split(n_folds=5)
+# algo = BaselineOnly()
 
-for trainset, testset in data.folds():
-    algo.train(trainset)
-    predictions = algo.test(testset)
-    precision_recall_at_k(predictions, k=5, threshold=4)
+# for trainset, testset in data.folds():
+#     algo.train(trainset)
+#     predictions = algo.test(testset)
+#     print(precision_recall_at_k(predictions, k=5, threshold=4))
+
+def pred(true_r, est, u0=None):
+    """Just a small tool to build a prediction with appropriate format."""
+    return (u0, None, true_r, est, None)
+
+predictions = [pred(4, 4.99, u0='u1'), pred(3, 4.98, u0='u1'), pred(4, 4.97, u0='u1'), pred(4, 4.96,
+               u0='u1'), pred(4, 4.95, u0='u1'), pred(4, 4.94, u0='u1'), pred(4, 4.93, u0='u1'), pred(3, 4.92,
+               u0='u1'), pred(4, 4.91, u0='u1'), pred(3, 4.90, u0='u1'), pred(4, 4.89, u0='u1'), pred(3, 4.88,
+               u0='u1'), pred(3, 4.87, u0='u1'), pred(4, 4.86, u0='u1'), pred(3, 4.85, u0='u1'), pred(3, 4.84,
+               u0='u1'), pred(3, 4.83, u0='u1'), pred(3, 4.82, u0='u1'), pred(3, 4.81, u0='u1'), pred(4, 4.80,
+               u0='u1'), pred(4, 4.79, u0='u1'), pred(4, 4.78, u0='u1'), pred(4, 4.77, u0='u1'), pred(4, 4.76,
+               u0='u1'), pred(4, 4.75, u0='u1'), pred(4, 4.74, u0='u1'), pred(4, 4.73, u0='u1'), pred(4, 4.72,
+               u0='u1'), pred(4, 4.71, u0='u1'), pred(4, 4.70, u0='u1')]
+for i in range(1,11):
+    print(precision_recall_at_k(predictions, k=i, threshold=4))

--- a/examples/precision_recall_at_k.py
+++ b/examples/precision_recall_at_k.py
@@ -1,9 +1,5 @@
 """
 This module illustrates how to compute Precision at k and Recall at k metrics.
-We first train an SVD algorithm on the MovieLens dataset, and then predict all
-the ratings for the pairs (user, item) that are not in the training set. We
-then compute Precision at k and Recall at k based on user defined k and
-threshold values.
 """
 
 from __future__ import (absolute_import, division, print_function,
@@ -14,7 +10,7 @@ from surprise import Dataset
 from surprise import SVD
 
 
-def precision_recall_at_k(predictions, k=10, threshold=3.5, verbose=True):
+def precision_recall_at_k(predictions, k=10, threshold=3.5):
     '''Return Precision and recall at k metrics for each user.
 
     Args:
@@ -48,13 +44,12 @@ def precision_recall_at_k(predictions, k=10, threshold=3.5, verbose=True):
                 est, true_r) in user_ratings[:k])
 
         # Count number of recommended items in top k
-        n_rec_k = sum(
-            (est >= threshold) for (est, _) in user_ratings[:k])
+        n_rec_k = sum((est >= threshold) for (est, _) in user_ratings[:k])
 
-        # Precision@K: Proportion of top-k documents that are relevant
+        # Precision@K: Proportion of recommended items that are relevant
         precision_at_k = n_rel_and_rec_k / n_rec_k if n_rec_k != 0 else 1
 
-        # Recall@K: Proportion of relevant items that are in the top-k
+        # Recall@K: Proportion of relevant items that are recommended
         recall_at_k = n_rel_and_rec_k / n_rel if n_rel != 0 else 1
 
         precision_recall_k[uid] = (precision_at_k, recall_at_k)
@@ -63,7 +58,6 @@ def precision_recall_at_k(predictions, k=10, threshold=3.5, verbose=True):
 
 
 data = Dataset.load_builtin('ml-100k')
-
 data.split(n_folds=5)
 algo = SVD()
 

--- a/examples/precision_recall_at_k.py
+++ b/examples/precision_recall_at_k.py
@@ -8,7 +8,7 @@ from surprise import SVD
 
 
 def precision_recall_at_k(predictions, k=10, threshold=3.5, verbose=True):
-    '''Return Precision and recall at K metrics for each user.
+    '''Return Precision and recall at k metrics for each user.
 
     Args:
         predictions(list of Prediction objects): The list of predictions, as
@@ -41,10 +41,10 @@ def precision_recall_at_k(predictions, k=10, threshold=3.5, verbose=True):
         n_rel_at_k = len([i for i in true_r_list_k if i >= threshold])
 
         # Precision@K: Proportion of top-k documents that are relevant
-        precision_at_k = float(n_rel_at_k)/k
+        precision_at_k = float(n_rel_at_k) / k
 
         # Recall@K: Proportion of relevant items that are in the top-k
-        recall_at_k = float(n_rel_at_k)/n_rel if n_rel != 0 else 1
+        recall_at_k = float(n_rel_at_k) / n_rel if n_rel != 0 else 1
 
         precision_recall_k[uid] = (precision_at_k, recall_at_k)
 

--- a/examples/precision_recall_at_k.py
+++ b/examples/precision_recall_at_k.py
@@ -1,0 +1,89 @@
+from __future__ import (absolute_import, division, print_function,
+                        unicode_literals)
+
+from collections import defaultdict
+import numpy as np
+
+from surprise import Dataset
+from surprise import SVD
+
+
+def precision_recall_at_k(predictions, k=10, threshold=3.5, verbose=True):
+    '''Return mean precision and recall at k for all users.
+
+    Args:
+        predictions(list of Prediction objects): The list of predictions, as
+            returned by the test method of an algorithm.
+        k(int): The number of recommendations for which precision and recall
+            will be computed. Default is 10.
+        threshold(float): A value after which ratings are considered positive.
+            Default is 3.5
+    Returns:
+    A tuple with the value (Precision@k, Recall@k)
+    '''
+
+    # First map the predictions to each user.
+    top_n = defaultdict(list)
+    for uid, iid, true_r, est, _ in predictions:
+        top_n[uid].append([iid, est, true_r])
+
+    # Create empty array to hold precisions and recalls for all users
+    precisions = []
+    recalls = []
+
+    # Then sort the predictions for each user and retrieve the k highest ones.
+    for uid, user_ratings_array in top_n.items():
+        user_ratings_array = np.array(user_ratings_array)
+        user_ratings_array_sorted = (
+                user_ratings_array[user_ratings_array[:, 1].argsort()[::-1]])
+
+        top_k_items = user_ratings_array_sorted[:k]
+
+        user_precision, user_recall = user_precision_recall(
+            top_k_items, threshold)
+        precisions.append(user_precision)
+        recalls.append(user_recall)
+    if verbose:
+        print(('Precision at %d is %1.4f') % (k, np.mean(precisions)))
+        print(('Recall at %d is %1.4f') % (k, np.mean(recalls)))
+    return (np.mean(precisions), np.mean(recalls))
+
+
+def user_precision_recall(top_preds, threshold):
+    '''Return mean precision and recall for a specific user.
+
+    Args:
+        top_preds(numpy 2d array): An array of [iid, est, true_r]
+        threshold(float): A value after which ratings are considered positive.
+
+    Returns:
+    A tuple with the value (Precision, Recall)
+    '''
+
+    # Count the number of relevant, recommended and
+    # (relevant and recommended) items
+    is_relevant = np.greater_equal(top_preds[:, 2].astype(float), threshold)
+    is_recommended = np.greater_equal(top_preds[:, 1].astype(float), threshold)
+    is_relevant_and_recommended = np.logical_and(is_relevant, is_recommended)
+    n_rel = np.sum(is_relevant)
+    n_rec = np.sum(is_recommended)
+    n_rel_and_rec = np.sum(is_relevant_and_recommended)
+
+    # We do not have any false positive (Recommended AND (Not relevant))
+    precision = float(n_rel_and_rec) / n_rec if n_rec != 0 else 1
+
+    # We do not have any false negative ((Not recommended) AND (relevant))
+    recall = float(n_rel_and_rec) / n_rel if n_rel != 0 else 1
+    return(precision, recall)
+
+
+# First train an SVD algorithm on the movielens dataset.
+data = Dataset.load_builtin('ml-100k')
+
+data.split(n_folds=5)
+algo = SVD()
+
+for trainset, testset in data.folds():
+    algo.train(trainset)
+    predictions = algo.test(testset)
+    precision_recall_at_k(predictions, k=5, threshold=4)


### PR DESCRIPTION
This issue resolves the discussion in #70.

For cases where denominator is zero, the case is handled as explained [here](https://stats.stackexchange.com/questions/1773/what-are-correct-values-for-precision-and-recall-in-edge-cases). I believe this is different from how it is handled in the lyst/lightfm library [here](https://github.com/lyst/lightfm/blob/master/lightfm/evaluation.py)
