### PR TITLE
alternate filling for missing values

### DIFF
--- a/surprise/dataset.py
+++ b/surprise/dataset.py
@@ -681,9 +681,9 @@ class Trainset:
         trainset. As :math:`r_{ui}` is unknown, it is assumed to be equal to
         the mean of all ratings :meth:`global_mean
         <surprise.dataset.Trainset.global_mean>`.
-        When fill is :code:`None` (default), the global mean will be used as a
-        replacement for unknown values. Otherwise, the :code:`fill` value will
-        be used for replacement.
+        When :code:`fill` is :code:`None` (default), the global mean will be
+        used as a replacement for unknown values. Otherwise, the :code:`fill`
+        value will be used for replacement.
         """
         fill = self.global_mean if fill is None else float(fill)
 

--- a/surprise/dataset.py
+++ b/surprise/dataset.py
@@ -678,12 +678,17 @@ class Trainset:
         The ratings are all the ratings that are **not** in the trainset, i.e.
         all the ratings :math:`r_{ui}` where the user :math:`u` is known, the
         item :math:`i` is known, but the rating :math:`r_{ui}`  is not in the
-        trainset. As :math:`r_{ui}` is unknown, it is assumed to be equal to
-        the mean of all ratings :meth:`global_mean
-        <surprise.dataset.Trainset.global_mean>`.
-        When :code:`fill` is :code:`None` (default), the global mean will be
-        used as a replacement for unknown values. Otherwise, the :code:`fill`
-        value will be used for replacement.
+        trainset. As :math:`r_{ui}` is unknown, it is either replaced by the
+        :code:`fill` value or assumed to be equal to the mean of all ratings
+        :meth:`global_mean <surprise.dataset.Trainset.global_mean>`.
+
+        Args:
+            fill(float): The value to fill unknown ratings. If :code:`None` the
+                global mean of all ratings :meth:`global_mean
+                <surprise.dataset.Trainset.global_mean>` will be used.
+
+        Returns:
+            A tuple ``(uid, iid, fill)`` where ids are raw ids.
         """
         fill = self.global_mean if fill is None else float(fill)
 

--- a/surprise/dataset.py
+++ b/surprise/dataset.py
@@ -670,7 +670,7 @@ class Trainset:
         return [(self.to_raw_uid(u), self.to_raw_iid(i), r)
                 for (u, i, r) in self.all_ratings()]
 
-    def build_anti_testset(self):
+    def build_anti_testset(self, fill=None):
         """Return a list of ratings that can be used as a testset in the
         :meth:`test() <surprise.prediction_algorithms.algo_base.AlgoBase.test>`
         method.
@@ -681,7 +681,11 @@ class Trainset:
         trainset. As :math:`r_{ui}` is unknown, it is assumed to be equal to
         the mean of all ratings :meth:`global_mean
         <surprise.dataset.Trainset.global_mean>`.
+        When fill is :code:`None` (default), the global mean will be used as a
+        replacement for unknown values. Otherwise, the :code:`fill` value will
+        be used for replacement.
         """
+        fill = self.global_mean if fill is None else float(fill)
 
         anti_testset = []
         for u in self.all_users():
@@ -689,7 +693,7 @@ class Trainset:
                 user_items = [j for (j, _) in self.ur[u]]
                 if i not in user_items:
                     r_ui = (self.to_raw_uid(u), self.to_raw_iid(i),
-                            self.global_mean)
+                            fill)
                     anti_testset.append(r_ui)
         return anti_testset
 

--- a/surprise/dataset.py
+++ b/surprise/dataset.py
@@ -688,7 +688,7 @@ class Trainset:
                 <surprise.dataset.Trainset.global_mean>` will be used.
 
         Returns:
-            A tuple ``(uid, iid, fill)`` where ids are raw ids.
+            A list of tuples ``(uid, iid, fill)`` where ids are raw ids.
         """
         fill = self.global_mean if fill is None else float(fill)
 

--- a/tests/test_dataset.py
+++ b/tests/test_dataset.py
@@ -197,3 +197,27 @@ def test_load_form_df():
     trainset = data.build_full_trainset()
     with pytest.raises(ValueError):
         trainset.to_inner_uid('10000')
+
+
+def test_build_anti_dataset():
+    ratings_dict = {'itemID': [1, 2, 3, 4, 5, 6, 7, 8],
+                    'userID': [1, 2, 3, 4, 5, 6, 7, 8],
+                    'rating': [1, 2, 3, 4, 5, 6, 7, 8]}
+    df = pd.DataFrame(ratings_dict)
+
+    reader = Reader(rating_scale=(1, 5))
+    data = Dataset.load_from_df(df[['userID', 'itemID', 'rating']], reader)
+    data.split(2)
+    trainset, __testset = next(data.folds())
+    # fill with some specific value
+    for fillvalue in (0, 42., -1):
+        anti = trainset.build_anti_testset(fill=fillvalue)
+        for (u, i, r) in anti:
+            assert r == fillvalue
+
+    # fill with global_mean
+    anti = trainset.build_anti_testset(fill=None)
+    for (u, i, r) in anti:
+        assert r == trainset.global_mean
+    expect = trainset.n_users * trainset.n_items  # all disjunct
+    assert trainset.n_ratings + len(anti) == expect

--- a/tests/test_dataset.py
+++ b/tests/test_dataset.py
@@ -199,10 +199,10 @@ def test_load_form_df():
         trainset.to_inner_uid('10000')
 
 
-def test_build_anti_dataset():
-    ratings_dict = {'itemID': [1, 2, 3, 4, 5, 6, 7, 8],
-                    'userID': [1, 2, 3, 4, 5, 6, 7, 8],
-                    'rating': [1, 2, 3, 4, 5, 6, 7, 8]}
+def test_build_anti_testset():
+    ratings_dict = {'itemID': [1, 2, 3, 4, 5, 6, 7, 8, 9],
+                    'userID': [1, 2, 3, 4, 5, 6, 7, 8, 9],
+                    'rating': [1, 2, 3, 4, 5, 6, 7, 8, 9]}
     df = pd.DataFrame(ratings_dict)
 
     reader = Reader(rating_scale=(1, 5))
@@ -214,10 +214,9 @@ def test_build_anti_dataset():
         anti = trainset.build_anti_testset(fill=fillvalue)
         for (u, i, r) in anti:
             assert r == fillvalue
-
     # fill with global_mean
     anti = trainset.build_anti_testset(fill=None)
     for (u, i, r) in anti:
         assert r == trainset.global_mean
-    expect = trainset.n_users * trainset.n_items  # all disjunct
+    expect = trainset.n_users * trainset.n_items
     assert trainset.n_ratings + len(anti) == expect


### PR DESCRIPTION
Hey there,

This PR allows filling unknown ratings with other values than the global rating mean in 
`datasets.build_anti_testset()`. Tests succeeded and docs compiled. No new test written yet.

Best Regards
Lukas

EDIT: while checking older issues and PRs (esp. #46), I realized that implicit feedback is not considered a use-case so far. To clarify, this PR also targets such implicit feedback scenarios by dealing with highly sparse `(user, item, rating)` triples. What is your current opinion on extending the package towards implicit feedback?