### PR TITLE
Adding encoding parameter to load method.

### DIFF
--- a/surprise/dump.py
+++ b/surprise/dump.py
@@ -54,6 +54,6 @@ def load(file_name, encoding='ASCII'):
 
     """
 
-    dump_obj = pickle.load(open(file_name, 'rb'), encoding='ASCII')
+    dump_obj = pickle.load(open(file_name, 'rb'), encoding=encoding)
 
     return dump_obj['predictions'], dump_obj['algo']

--- a/surprise/dump.py
+++ b/surprise/dump.py
@@ -41,7 +41,7 @@ def load(file_name, encoding='ASCII'):
     Args:
         file_name(str): The path of the file from which the algorithm is
             to be loaded
-        encoding(str, optional): Encoding that pickle should use.
+        encoding(str, optional): Pickle encoding (only supported on Python3).
             default value is 'ASCII'.
 
     Returns:
@@ -54,6 +54,9 @@ def load(file_name, encoding='ASCII'):
 
     """
 
-    dump_obj = pickle.load(open(file_name, 'rb'), encoding=encoding)
+    try:
+        dump_obj = pickle.load(open(file_name, 'rb'), encoding=encoding)
+    except TypeError:  # python2 does not know about encoding
+        dump_obj = pickle.load(open(file_name, 'rb'))
 
     return dump_obj['predictions'], dump_obj['algo']

--- a/surprise/dump.py
+++ b/surprise/dump.py
@@ -33,7 +33,7 @@ def dump(file_name, predictions=None, algo=None, verbose=0):
         print('The dump has been saved as file', file_name)
 
 
-def load(file_name):
+def load(file_name, encoding='ASCII'):
     """A basic wrapper around Pickle to deserialize a list of prediction and/or
     an algorithm that were dumped on drive using :func:`dump()
     <surprise.dump.dump>`.
@@ -41,6 +41,8 @@ def load(file_name):
     Args:
         file_name(str): The path of the file from which the algorithm is
             to be loaded
+        encoding(str, optional): Encoding that pickle should use.
+            default value is 'ASCII'.
 
     Returns:
         A tuple ``(predictions, algo)`` where ``predictions`` is a list of
@@ -52,6 +54,6 @@ def load(file_name):
 
     """
 
-    dump_obj = pickle.load(open(file_name, 'rb'))
+    dump_obj = pickle.load(open(file_name, 'rb'), encoding='ASCII')
 
     return dump_obj['predictions'], dump_obj['algo']


### PR DESCRIPTION
When this option is not available if a user has saved a file with different encoding then an error similar to this can be seen:
UnicodeDecodeError: 'ascii' codec can't decode byte 0xf0 in position 6: ordinal not in range(128)
