### PR TITLE
The dump function works with datasets of size > 4GB now.

### DIFF
--- a/surprise/dump.py
+++ b/surprise/dump.py
@@ -27,7 +27,8 @@ def dump(file_name, predictions=None, algo=None, verbose=0):
     dump_obj = {'predictions': predictions,
                 'algo': algo
                 }
-    pickle.dump(dump_obj, open(file_name, 'wb'))
+    pickle.dump(dump_obj, open(file_name, 'wb'),
+                protocol=pickle.HIGHEST_PROTOCOL)
 
     if verbose:
         print('The dump has been saved as file', file_name)


### PR DESCRIPTION
A little tweak to deal with huge datasets. The dump function has the 'protocol' argument since python 2.3, so this should cover lots of versions.