### PR TITLE
fix for windows use of joblib: n_jobs=1

### DIFF
--- a/surprise/evaluate.py
+++ b/surprise/evaluate.py
@@ -150,7 +150,7 @@ class GridSearch:
                 used.  For example, with ``n_jobs = -2`` all CPUs but one are\
                 used.
 
-            Default is ``-1``.
+            Default is ``1``.
         pre_dispatch(int or string): Controls the number of jobs that get
             dispatched during parallel execution. Reducing this number can be
             useful to avoid an explosion of memory consumption when more jobs
@@ -195,7 +195,7 @@ class GridSearch:
         """
 
     def __init__(self, algo_class, param_grid, measures=['rmse', 'mae'],
-                 n_jobs=-1, pre_dispatch='2*n_jobs', seed=None, verbose=1,
+                 n_jobs=1, pre_dispatch='2*n_jobs', seed=None, verbose=1,
                  joblib_verbose=0):
         self.best_params = CaseInsensitiveDefaultDict(list)
         self.best_index = CaseInsensitiveDefaultDict(list)

--- a/surprise/model_selection/search.py
+++ b/surprise/model_selection/search.py
@@ -19,7 +19,7 @@ class BaseSearchCV(with_metaclass(ABCMeta)):
 
     @abstractmethod
     def __init__(self, algo_class, measures=['rmse', 'mae'], cv=None,
-                 refit=False, return_train_measures=False, n_jobs=-1,
+                 refit=False, return_train_measures=False, n_jobs=1,
                  pre_dispatch='2*n_jobs', joblib_verbose=0):
 
         self.algo_class = algo_class
@@ -253,7 +253,7 @@ class GridSearchCV(BaseSearchCV):
                 used.  For example, with ``n_jobs = -2`` all CPUs but one are\
                 used.
 
-            Default is ``-1``.
+            Default is ``1``.
         pre_dispatch(int or string): Controls the number of jobs that get
             dispatched during parallel execution. Reducing this number can be
             useful to avoid an explosion of memory consumption when more jobs
@@ -295,7 +295,7 @@ class GridSearchCV(BaseSearchCV):
             <cv_results_example>`).
     """
     def __init__(self, algo_class, param_grid, measures=['rmse', 'mae'],
-                 cv=None, refit=False, return_train_measures=False, n_jobs=-1,
+                 cv=None, refit=False, return_train_measures=False, n_jobs=1,
                  pre_dispatch='2*n_jobs', joblib_verbose=0):
 
         super(GridSearchCV, self).__init__(
@@ -362,7 +362,7 @@ class RandomizedSearchCV(BaseSearchCV):
                 used.  For example, with ``n_jobs = -2`` all CPUs but one are\
                 used.
 
-            Default is ``-1``.
+            Default is ``1``.
         pre_dispatch(int or string): Controls the number of jobs that get
             dispatched during parallel execution. Reducing this number can be
             useful to avoid an explosion of memory consumption when more jobs
@@ -412,7 +412,7 @@ class RandomizedSearchCV(BaseSearchCV):
     """
     def __init__(self, algo_class, param_distributions, n_iter=10,
                  measures=['rmse', 'mae'], cv=None, refit=False,
-                 return_train_measures=False, n_jobs=-1,
+                 return_train_measures=False, n_jobs=1,
                  pre_dispatch='2*n_jobs', random_state=None, joblib_verbose=0):
 
         super(RandomizedSearchCV, self).__init__(

--- a/surprise/model_selection/validation.py
+++ b/surprise/model_selection/validation.py
@@ -15,7 +15,7 @@ from .. import accuracy
 
 
 def cross_validate(algo, data, measures=['rmse', 'mae'], cv=None,
-                   return_train_measures=False, n_jobs=-1,
+                   return_train_measures=False, n_jobs=1,
                    pre_dispatch='2*n_jobs', verbose=False):
     '''
     Run a cross validation procedure for a given algorithm, reporting accuracy
@@ -50,7 +50,7 @@ def cross_validate(algo, data, measures=['rmse', 'mae'], cv=None,
                 used.  For example, with ``n_jobs = -2`` all CPUs but one are\
                 used.
 
-            Default is ``-1``.
+            Default is ``1``.
         pre_dispatch(int or string): Controls the number of jobs that get
             dispatched during parallel execution. Reducing this number can be
             useful to avoid an explosion of memory consumption when more jobs

--- a/tests/test_grid_search.py
+++ b/tests/test_grid_search.py
@@ -101,7 +101,7 @@ def test_same_splits():
     # all RMSE should be the same (as param combinations are the same)
     param_grid = {'n_epochs': [1, 1], 'lr_all': [.5, .5]}
     with pytest.warns(UserWarning):
-        grid_search = GridSearch(SVD, param_grid, measures=['RMSE'], n_jobs=1)
+        grid_search = GridSearch(SVD, param_grid, measures=['RMSE'], n_jobs=-1)
     grid_search.evaluate(data)
 
     rmse_scores = [s['RMSE'] for s in grid_search.cv_results['scores']]

--- a/tests/test_grid_search.py
+++ b/tests/test_grid_search.py
@@ -101,7 +101,7 @@ def test_same_splits():
     # all RMSE should be the same (as param combinations are the same)
     param_grid = {'n_epochs': [1, 1], 'lr_all': [.5, .5]}
     with pytest.warns(UserWarning):
-        grid_search = GridSearch(SVD, param_grid, measures=['RMSE'], n_jobs=-1)
+        grid_search = GridSearch(SVD, param_grid, measures=['RMSE'], n_jobs=1)
     grid_search.evaluate(data)
 
     rmse_scores = [s['RMSE'] for s in grid_search.cv_results['scores']]

--- a/tests/test_search.py
+++ b/tests/test_search.py
@@ -88,7 +88,7 @@ def test_gridsearchcv_same_splits():
     param_grid = {'n_epochs': [5], 'lr_all': [.2, .2],
                   'reg_all': [.4, .4], 'n_factors': [5], 'random_state': [0]}
     gs = GridSearchCV(SVD, param_grid, measures=['RMSE'], cv=kf,
-                      n_jobs=-1)
+                      n_jobs=1)
     gs.fit(data)
 
     rmse_scores = [m for m in gs.cv_results['mean_test_rmse']]
@@ -275,7 +275,7 @@ def test_randomizedsearchcv_same_splits():
                            'reg_all': uniform(.4, 0), 'n_factors': [5],
                            'random_state': [0]}
     rs = RandomizedSearchCV(SVD, param_distributions, measures=['RMSE'], cv=kf,
-                            n_jobs=-1)
+                            n_jobs=1)
     rs.fit(data)
 
     rmse_scores = [m for m in rs.cv_results['mean_test_rmse']]


### PR DESCRIPTION
Setting n_jobs to 1 to make this library windows friendly. This could fix #139 
This is important as non of the examples/code run in windows.

Note: Additional information might have to be added in examples or documentation reflecting the change and how to force parallelization using n_jobs=1 and in change log where applicable. 