### PR TITLE
Option to add user and/or item features

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -24,3 +24,4 @@ _site
 .coverage
 tags
 settings.json
+surprise/.DS_Store

--- a/README.md
+++ b/README.md
@@ -190,7 +190,7 @@ Contributors
 The following persons have contributed to [Surprise](http://surpriselib.com):
 
 Олег Демиденко, Charles-Emmanuel Dias, Lukas Galke, Pierre-François Gimenez, Nicolas Hug,
-Hengji Liu,  Maher Malaeb, Naturale0, nju-luke, Skywhat, Mike Lee Williams,
+Hengji Liu,  Maher Malaeb, Naturale0, nju-luke, Skywhat, David Stevens, Mike Lee Williams,
 Chenchen Xu.
 
 Thanks a lot :) !

--- a/surprise/dataset.py
+++ b/surprise/dataset.py
@@ -53,6 +53,8 @@ class Dataset:
     def __init__(self, reader):
 
         self.reader = reader
+        self.raw_user_features = None
+        self.raw_item_features = None
 
     @classmethod
     def load_builtin(cls, name='ml-100k'):
@@ -164,6 +166,28 @@ class Dataset:
         """
 
         return DatasetAutoFolds(reader=reader, df=df)
+
+    def load_features_df(self, features_df, user_features=True):
+        """Load features from a pandas dataframe into a dataset.
+
+        Use this if you want to add user or item features to a dataset. Only
+        certain prediction algorithms in the :mod:`prediction_algorithms`
+        package support this additional data.
+
+        Args:
+            features_df(`Dataframe`): The dataframe containing the features. It
+                must have two columns or more, corresponding to the user or
+                item (raw) ids, and the features, in this order.
+            user_features(:obj:`bool`): Whether the features are for the users
+                or the items. Default is ``True``.
+        """
+
+        if user_features:
+            self.user_features_df = features_df
+            self.raw_user_features = features_df.values.tolist()
+        else:
+            self.item_features_df = features_df
+            self.raw_item_features = features_df.values.tolist()
 
     def read_ratings(self, file_name):
         """Return a list of ratings (user, item, rating, timestamp) read from

--- a/surprise/dataset.py
+++ b/surprise/dataset.py
@@ -274,12 +274,18 @@ class Dataset:
 
         n_users = len(ur)  # number of users
         n_items = len(ir)  # number of items
+        n_user_features = len(u_features)
+        n_item_features = len(i_features)
         n_ratings = len(raw_trainset)
 
         trainset = Trainset(ur,
                             ir,
+                            u_features,
+                            i_features,
                             n_users,
                             n_items,
+                            n_user_features,
+                            n_item_features,
                             n_ratings,
                             self.reader.rating_scale,
                             self.reader.offset,

--- a/surprise/dataset.py
+++ b/surprise/dataset.py
@@ -53,8 +53,8 @@ class Dataset:
     def __init__(self, reader):
 
         self.reader = reader
-        self.user_features = None
-        self.item_features = None
+        self.user_features_nb = 0
+        self.item_features_nb = 0
 
     @classmethod
     def load_builtin(cls, name='ml-100k'):
@@ -250,7 +250,7 @@ class Dataset:
                 uid = current_u_index
                 raw2inner_id_users[urid] = current_u_index
                 current_u_index += 1
-                if self.user_features is not None:
+                if self.user_features_nb > 0:
                     try:
                         u_features[uid] = self.user_features[urid]
                     except KeyError:
@@ -263,7 +263,7 @@ class Dataset:
                 iid = current_i_index
                 raw2inner_id_items[irid] = current_i_index
                 current_i_index += 1
-                if self.item_features is not None:
+                if self.item_features_nb > 0:
                     try:
                         i_features[iid] = self.item_features[irid]
                     except KeyError:
@@ -276,8 +276,6 @@ class Dataset:
 
         n_users = len(ur)  # number of users
         n_items = len(ir)  # number of items
-        n_user_features = len(u_features)
-        n_item_features = len(i_features)
         n_ratings = len(raw_trainset)
 
         trainset = Trainset(ur,
@@ -286,8 +284,8 @@ class Dataset:
                             i_features,
                             n_users,
                             n_items,
-                            n_user_features,
-                            n_item_features,
+                            self.user_features_nb,
+                            self.item_features_nb,
                             n_ratings,
                             self.reader.rating_scale,
                             self.reader.offset,

--- a/surprise/dataset.py
+++ b/surprise/dataset.py
@@ -195,6 +195,8 @@ class Dataset:
             self.item_features_labels = features_df.columns.values.tolist()[1:]
             self.item_features_nb = len(self.item_features_labels)
 
+        return self
+
     def read_ratings(self, file_name):
         """Return a list of ratings (user, item, rating, timestamp) read from
         file_name"""
@@ -252,7 +254,7 @@ class Dataset:
                     try:
                         u_features[uid] = self.user_features[urid]
                     except KeyError:
-                        print('user ' + urid + ' does not exist in ' +
+                        print('user ' + str(urid) + ' does not exist in ' +
                               'self.user_features')
                         raise
             try:
@@ -265,7 +267,7 @@ class Dataset:
                     try:
                         i_features[iid] = self.item_features[irid]
                     except KeyError:
-                        print('item ' + irid + ' does not exist in ' +
+                        print('item ' + str(irid) + ' does not exist in ' +
                               'self.item_features')
                         raise
 

--- a/surprise/prediction_algorithms/algo_base.py
+++ b/surprise/prediction_algorithms/algo_base.py
@@ -287,9 +287,9 @@ class AlgoBase(object):
             args += [self.trainset.global_mean, bx, by, shrinkage]
 
         try:
-            print('Computing the {0} similarity matrix...'.format(name))
+            # print('Computing the {0} similarity matrix...'.format(name))
             sim = construction_func[name](*args)
-            print('Done computing similarity matrix.')
+            # print('Done computing similarity matrix.')
             return sim
         except KeyError:
             raise NameError('Wrong sim name ' + name + '. Allowed values ' +

--- a/surprise/prediction_algorithms/algo_base.py
+++ b/surprise/prediction_algorithms/algo_base.py
@@ -240,7 +240,7 @@ class AlgoBase(object):
         method_name = self.bsl_options.get('method', 'als')
 
         try:
-            print('Estimating biases using', method_name + '...')
+            # print('Estimating biases using', method_name + '...')
             self.bu, self.bi = method[method_name](self)
             return self.bu, self.bi
         except KeyError:

--- a/surprise/trainset.py
+++ b/surprise/trainset.py
@@ -33,21 +33,34 @@ class Trainset:
         ir(:obj:`defaultdict` of :obj:`list`): The items ratings. This is a
             dictionary containing lists of tuples of the form ``(user_inner_id,
             rating)``. The keys are item inner ids.
+        u_features(:obj:`defaultdict` of :obj:`list`): The user features. This
+            is a dictionary containing lists of features. The keys are user
+            inner ids.
+        i_features(:obj:`defaultdict` of :obj:`list`): The item features. This
+            is a dictionary containing lists of features. The keys are item
+            inner ids.
         n_users: Total number of users :math:`|U|`.
         n_items: Total number of items :math:`|I|`.
+        n_user_features: Total number of user features.
+        n_item_features: Total number of item features.
         n_ratings: Total number of ratings :math:`|R_{train}|`.
         rating_scale(tuple): The minimum and maximal rating of the rating
             scale.
         global_mean: The mean of all ratings :math:`\\mu`.
     """
 
-    def __init__(self, ur, ir, n_users, n_items, n_ratings, rating_scale,
+    def __init__(self, ur, ir, u_features, i_features, n_users, n_items,
+                 n_user_features, n_item_features, n_ratings, rating_scale,
                  offset, raw2inner_id_users, raw2inner_id_items):
 
         self.ur = ur
         self.ir = ir
+        self.u_features = u_features
+        self.i_features = i_features
         self.n_users = n_users
         self.n_items = n_items
+        self.n_user_features = n_user_features
+        self.n_item_features = n_item_features
         self.n_ratings = n_ratings
         self.rating_scale = rating_scale
         self.offset = offset


### PR DESCRIPTION
I started modifying the Dataset and Trainset classes to include the option of having user and/or item features since I later want to work on an algorithm that accepts these. I think I made good progress but I still need to figure out how to create a testset with these features.

PS. It appears that this branch also included other modifications that I did with respect to asymetric_measures and the cancellation of printing for the computation of baselines and similarities. How can I create this pull request only with the commits on March 29, 2018?
