### PR TITLE
Fixed typo in kNN-basic and kNN-baseline

### DIFF
--- a/surprise/prediction_algorithms/knns.py
+++ b/surprise/prediction_algorithms/knns.py
@@ -68,7 +68,7 @@ class KNNBasic(SymmetricAlgo):
     .. math::
         \hat{r}_{ui} = \\frac{
         \\sum\\limits_{j \in N^k_u(i)} \\text{sim}(i, j) \cdot r_{uj}}
-        {\\sum\\limits_{j \in N^k_u(j)} \\text{sim}(i, j)}
+        {\\sum\\limits_{j \in N^k_u(i)} \\text{sim}(i, j)}
 
     depending on the ``user_based`` field of the ``sim_options`` parameter.
 
@@ -233,7 +233,7 @@ class KNNBaseline(SymmetricAlgo):
     .. math::
         \hat{r}_{ui} = b_{ui} + \\frac{ \\sum\\limits_{j \in N^k_u(i)}
         \\text{sim}(i, j) \cdot (r_{uj} - b_{uj})} {\\sum\\limits_{j \in
-        N^k_u(j)} \\text{sim}(i, j)}
+        N^k_u(i)} \\text{sim}(i, j)}
 
     depending on the ``user_based`` field of the ``sim_options`` parameter. For
     the best predictions, use the :func:`pearson_baseline


### PR DESCRIPTION
As per #203, this PR fixes the typos in kNN-basic and kNN-baseline. The denominators should be the neighbors of `i`, not `j`.

Closes #203