### PR TITLE
Add mean squared error (MSE) to accuracy

### DIFF
--- a/surprise/accuracy.py
+++ b/surprise/accuracy.py
@@ -9,6 +9,7 @@ Available accuracy metrics:
 
     rmse
     mae
+    mse
     fcp
 """
 
@@ -19,12 +20,46 @@ import numpy as np
 from six import iteritems
 
 
+def mse(predictions, verbose=True):
+    """Compute MSE (Mean Squared Error).
+
+    .. math::
+        \\text{MSE} = \\frac{1}{|\\hat{R}|} \\sum_{\\hat{r}_{ui} \in
+        \\hat{R}}(r_{ui} - \\hat{r}_{ui})^2
+
+    Args:
+        predictions (:obj:`list` of :obj:`Prediction\
+            <surprise.prediction_algorithms.predictions.Prediction>`):
+            A list of predictions, as returned by the :meth:`test()
+            <surprise.prediction_algorithms.algo_base.AlgoBase.test>` method.
+        verbose: If True, will print computed value. Default is ``True``.
+
+
+    Returns:
+        The Mean Squared Error of predictions.
+
+    Raises:
+        ValueError: When ``predictions`` is empty.
+    """
+
+    if not predictions:
+        raise ValueError('Prediction list is empty.')
+
+    mse_ = np.mean([float((true_r - est) ** 2)
+                    for (_, _, true_r, est, _) in predictions])
+
+    if verbose:
+        print('MSE:  {0:1.4f}'.format(mse_))
+
+    return mse_
+
+
 def rmse(predictions, verbose=True):
     """Compute RMSE (Root Mean Squared Error).
 
     .. math::
         \\text{RMSE} = \\sqrt{\\frac{1}{|\\hat{R}|} \\sum_{\\hat{r}_{ui} \in
-        \\hat{R}}(r_{ui} - \\hat{r}_{ui})^2}.
+        \\hat{R}}(r_{ui} - \\hat{r}_{ui})^2}
 
     Args:
         predictions (:obj:`list` of :obj:`Prediction\
@@ -44,9 +79,7 @@ def rmse(predictions, verbose=True):
     if not predictions:
         raise ValueError('Prediction list is empty.')
 
-    mse = np.mean([float((true_r - est)**2)
-                   for (_, _, true_r, est, _) in predictions])
-    rmse_ = np.sqrt(mse)
+    rmse_ = np.sqrt(mse(predictions))
 
     if verbose:
         print('RMSE: {0:1.4f}'.format(rmse_))

--- a/tests/test_accuracy.py
+++ b/tests/test_accuracy.py
@@ -6,7 +6,7 @@ from math import sqrt
 
 import pytest
 
-from surprise.accuracy import mae, rmse, fcp
+from surprise.accuracy import mae, rmse, fcp, mse
 
 
 def pred(true_r, est, u0=None):
@@ -37,20 +37,36 @@ def test_rmse():
     assert rmse(predictions) == 0
 
     predictions = [pred(0, 0), pred(0, 2)]
-    assert rmse(predictions) == sqrt((0 - 2)**2 / 2)
+    assert rmse(predictions) == sqrt((0 - 2) ** 2 / 2)
 
     predictions = [pred(2, 0), pred(3, 4)]
-    assert rmse(predictions) == sqrt(((2 - 0)**2 + (3 - 4)**2) / 2)
+    assert rmse(predictions) == sqrt(((2 - 0) ** 2 + (3 - 4) ** 2) / 2)
 
     with pytest.raises(ValueError):
         rmse([])
+
+
+def test_mse():
+    """Tests for the MSE function."""
+
+    predictions = [pred(0, 0), pred(1, 1), pred(2, 2), pred(100, 100)]
+    assert mse(predictions) == 0
+
+    predictions = [pred(0, 0), pred(0, 2)]
+    assert mse(predictions) == ((0 - 2) ** 2) / 2
+
+    predictions = [pred(2, 0), pred(3, 4)]
+    assert mse(predictions) == ((2 - 0) ** 2 + (3 - 4) ** 2) / 2
+
+    with pytest.raises(ValueError):
+        mse([])
 
 
 def test_fcp():
     """Tests for the FCP function."""
 
     predictions = [pred(0, 0, u0='u1'), pred(1, 1, u0='u1'), pred(2, 2,
-                   u0='u2'), pred(100, 100, u0='u2')]
+                                                                  u0='u2'), pred(100, 100, u0='u2')]
     assert fcp(predictions) == 1
 
     predictions = [pred(0, 0, u0='u1'), pred(0, 0, u0='u1')]
@@ -62,7 +78,7 @@ def test_fcp():
         fcp(predictions)
 
     predictions = [pred(0, 1, u0='u1'), pred(1, 0, u0='u1'), pred(2, 0.5,
-                   u0='u2'), pred(0, 0.6, u0='u2')]
+                                                                  u0='u2'), pred(0, 0.6, u0='u2')]
     assert fcp(predictions) == 0
 
     with pytest.raises(ValueError):

--- a/tests/test_evaluate.py
+++ b/tests/test_evaluate.py
@@ -30,9 +30,10 @@ def test_performances():
     algo = NormalPredictor()
     tmp_dir = tempfile.mkdtemp()  # create tmp dir
     with pytest.warns(UserWarning):
-        performances = evaluate(algo, data, measures=['RmSe', 'Mae'],
+        performances = evaluate(algo, data, measures=['RmSe', 'Mae', 'mse'],
                                 with_dump=True, dump_dir=tmp_dir, verbose=2)
     shutil.rmtree(tmp_dir)  # remove tmp dir
 
     assert performances['RMSE'] is performances['rmse']
     assert performances['MaE'] is performances['mae']
+    assert performances['MsE'] is performances['mse']


### PR DESCRIPTION
Hello,

I noticed that the MSE measurement is not in the accuracy module.

Of course you can get the MSE by squaring RMSE ^^.
But I think it would be more enjoyable if MSE is directly available.

So I pulled MSE out of RMSE and adjusted the corresponding tests.

I hope the request is justified.

Yours sincerely
Marc Feger
