### PR TITLE
Add warning to indicate unknown user and/or item

### DIFF
--- a/surprise/prediction_algorithms/baseline_only.py
+++ b/surprise/prediction_algorithms/baseline_only.py
@@ -38,11 +38,16 @@ class BaselineOnly(AlgoBase):
         return self
 
     def estimate(self, u, i):
+        known_user = self.trainset.knows_user(u)
+        known_item = self.trainset.knows_item(i)
+
+        if not (known_user and known_item):
+            print('Warning: User and/or item is unkown')
 
         est = self.trainset.global_mean
-        if self.trainset.knows_user(u):
+        if known_user:
             est += self.bu[u]
-        if self.trainset.knows_item(i):
+        if known_item:
             est += self.bi[i]
 
         return est

--- a/surprise/prediction_algorithms/knns.py
+++ b/surprise/prediction_algorithms/knns.py
@@ -283,16 +283,19 @@ class KNNBaseline(SymmetricAlgo):
         return self
 
     def estimate(self, u, i):
+        known_user = self.trainset.knows_user(u)
+        known_item = self.trainset.knows_item(i)
 
         est = self.trainset.global_mean
-        if self.trainset.knows_user(u):
+        if known_user:
             est += self.bu[u]
-        if self.trainset.knows_item(i):
+        if known_item:
             est += self.bi[i]
 
         x, y = self.switch(u, i)
 
-        if not (self.trainset.knows_user(u) and self.trainset.knows_item(i)):
+        if not (known_user and known_item):
+            print('Warning: User and/or item is unkown.')
             return est
 
         neighbors = [(x2, self.sim[x, x2], r) for (x2, r) in self.yr[y]]

--- a/surprise/prediction_algorithms/matrix_factorization.pyx
+++ b/surprise/prediction_algorithms/matrix_factorization.pyx
@@ -260,6 +260,9 @@ class SVD(AlgoBase):
         known_item = self.trainset.knows_item(i)
 
         if self.biased:
+            if not (known_user and known_item):
+                print('Warning: User and/or item is unkown')
+
             est = self.trainset.global_mean
 
             if known_user:
@@ -485,16 +488,21 @@ class SVDpp(AlgoBase):
         self.yj = yj
 
     def estimate(self, u, i):
+        known_user = self.trainset.knows_user(u)
+        known_item = self.trainset.knows_item(i)
+
+        if not (known_user and known_item):
+            print('Warning: User and/or item is unkown')
 
         est = self.trainset.global_mean
 
-        if self.trainset.knows_user(u):
+        if known_user:
             est += self.bu[u]
 
-        if self.trainset.knows_item(i):
+        if known_item:
             est += self.bi[i]
 
-        if self.trainset.knows_user(u) and self.trainset.knows_item(i):
+        if known_user and known_item:
             Iu = len(self.trainset.ur[u])  # nb of items rated by u
             u_impl_feedback = (sum(self.yj[j] for (j, _)
                                in self.trainset.ur[u]) / np.sqrt(Iu))
@@ -722,6 +730,9 @@ class NMF(AlgoBase):
         known_item = self.trainset.knows_item(i)
 
         if self.biased:
+            if not (known_user and known_item):
+                print('Warning: User and/or item is unkown.')
+
             est = self.trainset.global_mean
 
             if known_user:


### PR DESCRIPTION
For algorithms that produce a certain bias for unknown users and items, it seems better to at least warn the developer that he/she is inputting an unknown user and/or item ID. The use of raw IDs and the fact that they have to be the correct type is not confusing but for first time users of your library (like I a couple days ago), a clear warning that the given user ID or item ID is unknown would have saved me a lot of time.

E.g. I trained using SVD, SVDpp but for some strange reason I was getting the same prediction value for every single test example. I fiddled around with the learning rate and reg. weight for a day, and finally tried other algorithm. That's when I realized that for algorithms that doesn't produce an initial bias (NMF), it gave a clear prediction impossible error that both my user ID and item ID were unknown - turns out I was giving the wrong type of my IDs (str instead of int). 