### PR TITLE
Fix typo in FAQ

### DIFF
--- a/doc/source/FAQ.rst
+++ b/doc/source/FAQ.rst
@@ -200,7 +200,7 @@ seed of the RNG at the beginning of your program:
 
     my_seed = 0
     random.seed(my_seed)
-    numpy.random.seed(my_seed)
+    np.random.seed(my_seed)
 
 .. _data_folder:
 


### PR DESCRIPTION
Changed `numpy` to `np` in reproducible experiments section (setting random seed) to match import name