### PR TITLE
Fixed typo in predict() docstring

### DIFF
--- a/surprise/prediction_algorithms/algo_base.py
+++ b/surprise/prediction_algorithms/algo_base.py
@@ -85,7 +85,7 @@ class AlgoBase(object):
 
             - The (raw) user id ``uid``.
             - The (raw) item id ``iid``.
-            - The true rating ``r_ui`` (:math:`\\hat{r}_{ui}`).
+            - The true rating ``r_ui`` (:math:`r_{ui}`).
             - The estimated rating (:math:`\\hat{r}_{ui}`).
             - Some additional details about the prediction that might be useful
               for later analysis.


### PR DESCRIPTION
Removed extraneous hat from the true rating of the predict() returns comment. Checked on local fork using ".\make html". 

Thank you for the encouragement to submit a PR. This is my first ever, so I apologize if there are any mistakes (please let me know)!