### PR TITLE
Fix FilexExistsError due to race condition

### DIFF
--- a/surprise/builtin_datasets.py
+++ b/surprise/builtin_datasets.py
@@ -25,7 +25,7 @@ def get_dataset_dir():
         os.makedirs(folder)
     except OSError as e:
         if e.errno != errno.EEXIST:
-            # reraise exception if folder exists and creation failed.
+            # reraise exception if folder does not exist and creation failed.
             raise
 
     return folder

--- a/surprise/builtin_datasets.py
+++ b/surprise/builtin_datasets.py
@@ -4,11 +4,13 @@ downloaded.'''
 from __future__ import (absolute_import, division, print_function,
                         unicode_literals)
 
-from six.moves.urllib.request import urlretrieve
 import zipfile
-from collections import namedtuple
 import os
+import errno
+
 from os.path import join
+from collections import namedtuple
+from six.moves.urllib.request import urlretrieve
 
 
 def get_dataset_dir():
@@ -19,8 +21,12 @@ def get_dataset_dir():
 
     folder = os.environ.get('SURPRISE_DATA_FOLDER', os.path.expanduser('~') +
                             '/.surprise_data/')
-    if not os.path.exists(folder):
+    try:
         os.makedirs(folder)
+    except OSError as e:
+        if e.errno != errno.EEXIST:
+            # reraise exception if folder exists and creation failed.
+            raise
 
     return folder
 


### PR DESCRIPTION
I did not use `os.makedirs(folder, exist_ok=True)` as `exist_ok` is only available with Python 3.4+.
Implemented solution works for both Python 3.x and Python 2.7 (https://stackoverflow.com/a/42545343).

Exceptions due to race condition are not deterministic, thus I did not write a test for it. However, existing tests cover the code changes and pass. Also, the `FileExistsError` does not occur in my setup anymore.