### PR TITLE
[FIX] NMF: Handle 0 ratings

### DIFF
--- a/surprise/prediction_algorithms/matrix_factorization.pyx
+++ b/surprise/prediction_algorithms/matrix_factorization.pyx
@@ -700,7 +700,7 @@ class NMF(AlgoBase):
             for u in trainset.all_users():
                 n_ratings = len(trainset.ur[u])
                 for f in range(self.n_factors):
-                    if pu[u, f] != 0:
+                    if pu[u, f] != 0:  # Can happen if user only has 0 ratings
                         user_denom[u, f] += n_ratings * reg_pu * pu[u, f]
                         pu[u, f] *= user_num[u, f] / user_denom[u, f]
 

--- a/surprise/prediction_algorithms/matrix_factorization.pyx
+++ b/surprise/prediction_algorithms/matrix_factorization.pyx
@@ -700,15 +700,17 @@ class NMF(AlgoBase):
             for u in trainset.all_users():
                 n_ratings = len(trainset.ur[u])
                 for f in range(self.n_factors):
-                    user_denom[u, f] += n_ratings * reg_pu * pu[u, f]
-                    pu[u, f] *= user_num[u, f] / user_denom[u, f]
+                    if pu[u, f] != 0:
+                        user_denom[u, f] += n_ratings * reg_pu * pu[u, f]
+                        pu[u, f] *= user_num[u, f] / user_denom[u, f]
 
             # Update item factors
             for i in trainset.all_items():
                 n_ratings = len(trainset.ir[i])
                 for f in range(self.n_factors):
-                    item_denom[i, f] += n_ratings * reg_qi * qi[i, f]
-                    qi[i, f] *= item_num[i, f] / item_denom[i, f]
+                    if qi[i, f] != 0:
+                        item_denom[i, f] += n_ratings * reg_qi * qi[i, f]
+                        qi[i, f] *= item_num[i, f] / item_denom[i, f]
 
         self.bu = bu
         self.bi = bi


### PR DESCRIPTION
##### Issue
NMF crashed with `ZeroDivisionError: float division` when all ratings for a user (or. an item) were 0.

##### Description of changes
Fix `sgd()` to skip update step when the rating is 0. 

##### Alternative approach
The rating could be 'fixed' to a very small number to enable further updates.
