### PR TITLE
Fix 'rank_test_fcp' order in grid search cv_results.

### DIFF
--- a/surprise/model_selection/search.py
+++ b/surprise/model_selection/search.py
@@ -144,8 +144,11 @@ class BaseSearchCV(with_metaclass(ABCMeta)):
             # cv_results: set rank of each param comb
             indices = cv_results['mean_test_{}'.format(m)].argsort()
             cv_results['rank_test_{}'.format(m)] = np.empty_like(indices)
-            cv_results['rank_test_{}'.format(m)][indices] = np.arange(
-                len(indices)) + 1  # sklearn starts rankings at 1 as well.
+            if m in ('mae', 'rmse', 'mse'):
+              cv_results['rank_test_{}'.format(m)][indices] = np.arange(
+                  len(indices)) + 1  # sklearn starts rankings at 1 as well.
+            elif m in ('fcp',):
+              cv_results['rank_test_{}'.format(m)][indices] = np.arange(len(indices), 0, -1)
 
             # set best_index, and best_xxxx attributes
             if m in ('mae', 'rmse', 'mse'):

--- a/surprise/model_selection/search.py
+++ b/surprise/model_selection/search.py
@@ -142,18 +142,16 @@ class BaseSearchCV(with_metaclass(ABCMeta)):
                     train_measures[m].std(axis=1)
 
             # cv_results: set rank of each param comb
+            # also set best_index, and best_xxxx attributes
             indices = cv_results['mean_test_{}'.format(m)].argsort()
             cv_results['rank_test_{}'.format(m)] = np.empty_like(indices)
             if m in ('mae', 'rmse', 'mse'):
-              cv_results['rank_test_{}'.format(m)][indices] = np.arange(
-                  len(indices)) + 1  # sklearn starts rankings at 1 as well.
-            elif m in ('fcp',):
-              cv_results['rank_test_{}'.format(m)][indices] = np.arange(len(indices), 0, -1)
-
-            # set best_index, and best_xxxx attributes
-            if m in ('mae', 'rmse', 'mse'):
+                cv_results['rank_test_{}'.format(m)][indices] = \
+                    np.arange(len(indices)) + 1  # sklearn starts at 1 as well
                 best_index[m] = mean_test_measures.argmin()
             elif m in ('fcp',):
+                cv_results['rank_test_{}'.format(m)][indices] = \
+                    np.arange(len(indices), 0, -1)
                 best_index[m] = mean_test_measures.argmax()
             best_params[m] = self.param_combinations[best_index[m]]
             best_score[m] = mean_test_measures[best_index[m]]

--- a/tests/test_search.py
+++ b/tests/test_search.py
@@ -103,9 +103,9 @@ def test_gridsearchcv_cv_results():
     f = os.path.join(os.path.dirname(__file__), './u1_ml100k_test')
     data = Dataset.load_from_file(f, Reader('ml-100k'))
     kf = KFold(3, shuffle=True, random_state=4)
-    param_grid = {'n_epochs': [5], 'lr_all': [.2, .2],
-                  'reg_all': [.4, .4], 'n_factors': [5], 'random_state': [0]}
-    gs = GridSearchCV(SVD, param_grid, measures=['RMSE', 'mae'], cv=kf,
+    param_grid = {'n_epochs': [5], 'lr_all': [.2, .4],
+                  'reg_all': [.4, .6], 'n_factors': [5], 'random_state': [0]}
+    gs = GridSearchCV(SVD, param_grid, measures=['RMSE', 'mae', 'fcp'], cv=kf,
                       return_train_measures=True)
     gs.fit(data)
 
@@ -151,6 +151,8 @@ def test_gridsearchcv_cv_results():
     assert gs.cv_results['params'][best_index] == gs.best_params['rmse']
     best_index = np.argmin(gs.cv_results['rank_test_mae'])
     assert gs.cv_results['params'][best_index] == gs.best_params['mae']
+    best_index = np.argmin(gs.cv_results['rank_test_fcp'])
+    assert gs.cv_results['params'][best_index] == gs.best_params['fcp']
 
 
 def test_gridsearchcv_refit(u1_ml100k):


### PR DESCRIPTION
Added a few lines that rank FCP scores in the opposite direction, since the higher the FCP score is, the better it is, as opposed to MEA, RMSE, MSE.