### PR TITLE
docs: Fix a few typos

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -4,7 +4,7 @@ TODO
 * remove offset from everywhere (Reader, Trainset, test(), predict()...). Make
   a test to make sure that zero ratings are handled correctly. Right now we
   store ratings as defaultdict(list) in ur and ir, so there's no problem. Maybe
-  it will change in the future, we would have to find a workaroud.
+  it will change in the future, we would have to find a workaround.
 * rating_scale should be specified on dataset creation: load_from_file,
   load_from_folds, load_from_df. Deprecate its use from rating but fall back to
   it if it has only been specified here.

--- a/doc/source/FAQ.rst
+++ b/doc/source/FAQ.rst
@@ -53,7 +53,7 @@ You can use the :meth:`get_neighbors()
 <surprise.prediction_algorithms.algo_base.AlgoBase.get_neighbors>` methods of
 the algorithm object. This is only relevant for algorithms that use a
 similarity measure, such as the :ref:`k-NN algorithms
-<pred_package_knn_inspired>`.
+<pred_package_knn_inpired>`.
 
 Here is an example where we retrieve the 10 nearest neighbors of the movie Toy
 Story from the MovieLens-100k dataset. The output is:

--- a/doc/source/FAQ.rst
+++ b/doc/source/FAQ.rst
@@ -53,7 +53,7 @@ You can use the :meth:`get_neighbors()
 <surprise.prediction_algorithms.algo_base.AlgoBase.get_neighbors>` methods of
 the algorithm object. This is only relevant for algorithms that use a
 similarity measure, such as the :ref:`k-NN algorithms
-<pred_package_knn_inpired>`.
+<pred_package_knn_inspired>`.
 
 Here is an example where we retrieve the 10 nearest neighbors of the movie Toy
 Story from the MovieLens-100k dataset. The output is:

--- a/doc/source/getting_started.rst
+++ b/doc/source/getting_started.rst
@@ -196,7 +196,7 @@ Use cross-validation iterators
 
 For cross-validation, we can use the :func:`cross_validate()
 <surprise.model_selection.validation.cross_validate>` function that does all
-the hard work for us. But for a better control, we can also instanciate a
+the hard work for us. But for a better control, we can also instantiate a
 cross-validation iterator, and make predictions over each split using the
 ``split()`` method of the iterator, and the
 :meth:`test()<surprise.prediction_algorithms.algo_base.AlgoBase.test>` method

--- a/examples/k_nearest_neighbors.py
+++ b/examples/k_nearest_neighbors.py
@@ -31,7 +31,7 @@ def read_item_names():
     return rid_to_name, name_to_rid
 
 
-# First, train the algortihm to compute the similarities between items
+# First, train the algorithm to compute the similarities between items
 data = Dataset.load_builtin('ml-100k')
 trainset = data.build_full_trainset()
 sim_options = {'name': 'pearson_baseline', 'user_based': False}

--- a/surprise/prediction_algorithms/algo_base.py
+++ b/surprise/prediction_algorithms/algo_base.py
@@ -176,7 +176,7 @@ class AlgoBase(object):
         :ref:`baseline_estimates_configuration`).
 
         This method is only relevant for algorithms using :func:`Pearson
-        baseline similarty<surprise.similarities.pearson_baseline>` or the
+        baseline similarity<surprise.similarities.pearson_baseline>` or the
         :class:`BaselineOnly
         <surprise.prediction_algorithms.baseline_only.BaselineOnly>` algorithm.
 

--- a/surprise/prediction_algorithms/knns.py
+++ b/surprise/prediction_algorithms/knns.py
@@ -14,7 +14,7 @@ from .algo_base import AlgoBase
 
 # Important note: as soon as an algorithm uses a similarity measure, it should
 # also allow the bsl_options parameter because of the pearson_baseline
-# similarity. It can be done explicitely (e.g. KNNBaseline), or implicetely
+# similarity. It can be done explicitly (e.g. KNNBaseline), or implicetely
 # using kwargs (e.g. KNNBasic).
 
 class SymmetricAlgo(AlgoBase):

--- a/tests/test_zero_ratings.py
+++ b/tests/test_zero_ratings.py
@@ -13,7 +13,7 @@ between 0 ratings and missing ones.
 We currently store ratings as two defaultdict of lists (trainset.ur and
 trainset.ir), so 0 ratings should be handled correctly, without needing to
 remap them. Maybe it will change in the future, we would have to find a
-workaroud.
+workaround.
 """
 
 from __future__ import (absolute_import, division, print_function,


### PR DESCRIPTION
There are small typos in:
- doc/source/FAQ.rst
- doc/source/getting_started.rst
- examples/k_nearest_neighbors.py
- surprise/prediction_algorithms/algo_base.py
- surprise/prediction_algorithms/knns.py
- tests/test_zero_ratings.py

Fixes:
- Should read `workaround` rather than `workaroud`.
- Should read `similarity` rather than `similarty`.
- Should read `instantiate` rather than `instanciate`.
- Should read `explicitly` rather than `explicitely`.
- Should read `algorithm` rather than `algortihm`.



Semi-automated pull request generated by
https://github.com/timgates42/meticulous/blob/master/docs/NOTE.md