### PR TITLE
Replace np.int with np.int_

### DIFF
--- a/surprise/prediction_algorithms/co_clustering.pyx
+++ b/surprise/prediction_algorithms/co_clustering.pyx
@@ -186,13 +186,13 @@ class CoClustering(AlgoBase):
         cdef double global_mean = self.trainset.global_mean
 
         # Initialize everything to zero
-        count_cltr_u = np.zeros(self.n_cltr_u, np.int)
-        count_cltr_i = np.zeros(self.n_cltr_i, np.int)
-        count_cocltr = np.zeros((self.n_cltr_u, self.n_cltr_i), np.int)
+        count_cltr_u = np.zeros(self.n_cltr_u, np.int_)
+        count_cltr_i = np.zeros(self.n_cltr_i, np.int_)
+        count_cocltr = np.zeros((self.n_cltr_u, self.n_cltr_i), np.int_)
 
-        sum_cltr_u = np.zeros(self.n_cltr_u, np.int)
-        sum_cltr_i = np.zeros(self.n_cltr_i, np.int)
-        sum_cocltr = np.zeros((self.n_cltr_u, self.n_cltr_i), np.int)
+        sum_cltr_u = np.zeros(self.n_cltr_u, np.int_)
+        sum_cltr_i = np.zeros(self.n_cltr_i, np.int_)
+        sum_cocltr = np.zeros((self.n_cltr_u, self.n_cltr_i), np.int_)
 
         avg_cltr_u = np.zeros(self.n_cltr_u, np.double)
         avg_cltr_i = np.zeros(self.n_cltr_i, np.double)

--- a/surprise/prediction_algorithms/slope_one.pyx
+++ b/surprise/prediction_algorithms/slope_one.pyx
@@ -52,7 +52,7 @@ class SlopeOne(AlgoBase):
 
         AlgoBase.fit(self, trainset)
 
-        freq = np.zeros((trainset.n_items, trainset.n_items), np.int)
+        freq = np.zeros((trainset.n_items, trainset.n_items), np.int_)
         dev = np.zeros((trainset.n_items, trainset.n_items), np.double)
 
         # Computation of freq and dev arrays.

--- a/surprise/similarities.pyx
+++ b/surprise/similarities.pyx
@@ -67,7 +67,7 @@ def cosine(n_x, yr, min_support):
     cdef int min_sprt = min_support
 
     prods = np.zeros((n_x, n_x), np.double)
-    freq = np.zeros((n_x, n_x), np.int)
+    freq = np.zeros((n_x, n_x), np.int_)
     sqi = np.zeros((n_x, n_x), np.double)
     sqj = np.zeros((n_x, n_x), np.double)
     sim = np.zeros((n_x, n_x), np.double)
@@ -140,7 +140,7 @@ def msd(n_x, yr, min_support):
     cdef int min_sprt = min_support
 
     sq_diff = np.zeros((n_x, n_x), np.double)
-    freq = np.zeros((n_x, n_x), np.int)
+    freq = np.zeros((n_x, n_x), np.int_)
     sim = np.zeros((n_x, n_x), np.double)
 
     for y, y_ratings in yr.items():
@@ -216,7 +216,7 @@ def pearson(n_x, yr, min_support):
     cdef double ri, rj
     cdef int min_sprt = min_support
 
-    freq = np.zeros((n_x, n_x), np.int)
+    freq = np.zeros((n_x, n_x), np.int_)
     prods = np.zeros((n_x, n_x), np.double)
     sqi = np.zeros((n_x, n_x), np.double)
     sqj = np.zeros((n_x, n_x), np.double)
@@ -317,7 +317,7 @@ def pearson_baseline(n_x, yr, min_support, global_mean, x_biases, y_biases,
     cdef int min_sprt = min_support
     cdef double global_mean_ = global_mean
 
-    freq = np.zeros((n_x, n_x), np.int)
+    freq = np.zeros((n_x, n_x), np.int_)
     prods = np.zeros((n_x, n_x), np.double)
     sq_diff_i = np.zeros((n_x, n_x), np.double)
     sq_diff_j = np.zeros((n_x, n_x), np.double)


### PR DESCRIPTION
Removes a bunch of warnings.
See https://numpy.org/devdocs/release/1.20.0-notes.html#using-the-aliases-of-builtin-types-like-np-int-is-deprecated. I could just replace with `int` as well.