### PR TITLE
Improve similarities performance

### DIFF
--- a/surprise/similarities.pyx
+++ b/surprise/similarities.pyx
@@ -61,13 +61,15 @@ def cosine(int n_x, yr, int min_support):
     # the similarity matrix
     cdef double [:, ::1] sim = np.zeros((n_x, n_x), np.double)
 
-    cdef int xi, xj, y
+    cdef int xi, xj, y, i
     cdef double ri, rj
     cdef int min_sprt = min_support
 
-    for y, y_ratings in yr.items():
-        for xi, ri in y_ratings:
-            for xj, rj in y_ratings:
+    sorted_yr = { y : sorted(y_ratings, key = lambda x: x[0]) for y, y_ratings in yr.items() }
+
+    for y, y_ratings in sorted_yr.items():
+        for i, (xi, ri) in enumerate(y_ratings):
+            for xj, rj in y_ratings[i + 1:]:
                 freq[xi, xj] += 1
                 prods[xi, xj] += ri * rj
                 sqi[xi, xj] += ri**2
@@ -128,13 +130,15 @@ def msd(int n_x, yr, int min_support):
     # the similarity matrix
     cdef double [:, ::1] sim = np.zeros((n_x, n_x), np.double)
 
-    cdef int xi, xj
+    cdef int xi, xj, i
     cdef double ri, rj
     cdef int min_sprt = min_support
 
-    for y, y_ratings in yr.items():
-        for xi, ri in y_ratings:
-            for xj, rj in y_ratings:
+    sorted_yr = { y : sorted(y_ratings, key = lambda x: x[0]) for y, y_ratings in yr.items() }
+
+    for y, y_ratings in sorted_yr.items():
+        for i, (xi, ri) in enumerate(y_ratings):
+            for xj, rj in y_ratings[i + 1:]:
                 sq_diff[xi, xj] += (ri - rj)**2
                 freq[xi, xj] += 1
 
@@ -200,13 +204,15 @@ def pearson(int n_x, yr, int min_support):
     # the similarity matrix
     cdef double [:, ::1] sim = np.zeros((n_x, n_x), np.double)
 
-    cdef int xi, xj, y, n
+    cdef int xi, xj, y, n, i
     cdef double ri, rj, num, denum
     cdef int min_sprt = min_support
 
-    for y, y_ratings in yr.items():
-        for xi, ri in y_ratings:
-            for xj, rj in y_ratings:
+    sorted_yr = { y : sorted(y_ratings, key = lambda x: x[0]) for y, y_ratings in yr.items() }
+
+    for y, y_ratings in sorted_yr.items():
+        for i, (xi, ri) in enumerate(y_ratings):
+            for xj, rj in y_ratings[i + 1:]:
                 prods[xi, xj] += ri * rj
                 freq[xi, xj] += 1
                 sqi[xi, xj] += ri**2
@@ -296,7 +302,7 @@ def pearson_baseline(
     # the similarity matrix
     cdef double [:, ::1] sim = np.zeros((n_x, n_x), np.double)
 
-    cdef int y, xi, xj
+    cdef int y, xi, xj, i
     cdef double ri, rj, diff_i, diff_j, partial_bias
     cdef int min_sprt = min_support
     cdef double global_mean_ = global_mean
@@ -305,10 +311,12 @@ def pearson_baseline(
     # is 1, so that's OK.
     min_sprt = max(2, min_sprt)
 
-    for y, y_ratings in yr.items():
+    sorted_yr = { y : sorted(y_ratings, key = lambda x: x[0]) for y, y_ratings in yr.items() }
+
+    for y, y_ratings in sorted_yr.items():
         partial_bias = global_mean_ + y_biases[y]
-        for xi, ri in y_ratings:
-            for xj, rj in y_ratings:
+        for i, (xi, ri) in enumerate(y_ratings):
+            for xj, rj in y_ratings[i + 1:]:
                 freq[xi, xj] += 1
                 diff_i = (ri - (partial_bias + x_biases[xi]))
                 diff_j = (rj - (partial_bias + x_biases[xj]))


### PR DESCRIPTION
I'm trying to test multiple recommendation algorithms with a very big dataset (6M ratings, 69k users, 17k items) and I noticed that for algorithms that compute similarities the `fit` time is very high.

I found that there are some redundant operations that could be eliminated in order to speed up the similarities' computation.

In `similarities.pyx` when computing auxiliary values, like the freq, prods arrays, because `y_ratings` is not sorted we have to fully iterate over `y_ratings` two times resulting in N² operations for each `y_ratings` in `yr`.
```python
    for y, y_ratings in yr.items():
        for xi, ri in y_ratings:
            for xj, rj in y_ratings:
                freq[xi, xj] += 1
                prods[xi, xj] += ri * rj
                sqi[xi, xj] += ri**2
                sqj[xi, xj] += rj**2            
```

We can take advantage of the fact that all auxiliary matrices are symmetric (M[x][y] == M[y][X]) so filling the half above diagonal is enough to compute the similarities.

My change is sorting the `y_ratings` lists before filling the auxiliary arrays and changing the second for loop on `y_ratings` so that only the top half of the auxiliary matrices are filled. This reduces the number of operations for each element in `yr` from N² to N(N-1)/2.
```python
    sorted_yr = { y : sorted(y_ratings, key = lambda x: x[0]) for y, y_ratings in yr.items() }

    for y, y_ratings in sorted_yr.items():
        for i, (xi, ri) in enumerate(y_ratings):
            for xj, rj in y_ratings[i + 1:]:
```            

The sorting might reduce performance for small datasets, but for larger datasets like movielens-1m the performance gains are very noticeable.

Some performance tests I did on my laptop (Intel(R) Core(TM) i7-6500U CPU @ 2.50GHz). The time in the next tables are the average time it took to train (just the `.fit` method call) a KNNBasic algorithm over 50 samples.
Dataset: **movielens-1m**
|                  | Before (seconds) | After (seconds) | Time reduction (After/Before * 100) |
|------------------|-----------------|----------------|------------------------------------|
| cosine           | 32.58           | 13.78          | 42.29 %                            |
| msd              | 29.94           | 11.14          | 37.20 %                            |
| pearson          | 38.21           | 16.98          | 44.43 %                            |
| pearson_baseline | 38.26           | 17.86          | 46.68 %                            |

Dataset: **movielens-100k**
|                  | Before(seconds) | After(seconds) | Time reduction(After/Before * 100) |
|------------------|-----------------|----------------|------------------------------------|
| cosine           | 0.46            | 0.20           | 43.47 %                            |
| msd              | 0.28            | 0.15           | 53.57 %                            |
| pearson          | 0.58            | 0.27           | 46.55 %                            |
| pearson_baseline | 0.66            | 0.42           | 63.63 %                            |

Of course, all tests pass successfully.