### PR TITLE
Add upper bound to Numpy version

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,7 +21,7 @@ license = { "file" = "LICENSE.md" }
 dependencies = [
   # Lower bounds for deps are as in scikit-learn in May 2024, 1.6.dev0
   "joblib>=1.2.0",
-  "numpy>=1.19.5",
+  "numpy>=1.19.5,<2.0.0",
   "scipy>=1.6.0"
 ]
 dynamic = ["version", "readme"]


### PR DESCRIPTION
This pull request is meant to resolve #485 by adding an upper bound on the Numpy version until this package is ready to use Numpy 2.