### PR TITLE
Fix: modify deprecated datatype in `co_clustering.pyx`

### DIFF
--- a/surprise/prediction_algorithms/co_clustering.pyx
+++ b/surprise/prediction_algorithms/co_clustering.pyx
@@ -77,8 +77,8 @@ class CoClustering(AlgoBase):
         cdef np.ndarray[np.double_t] item_mean
 
         # User and items clusters
-        cdef np.ndarray[np.int_t] cltr_u
-        cdef np.ndarray[np.int_t] cltr_i
+        cdef np.ndarray[np.int64_t] cltr_u
+        cdef np.ndarray[np.int64_t] cltr_i
 
         # Average rating of user clusters, item clusters and co-clusters
         cdef np.ndarray[np.double_t] avg_cltr_u
@@ -154,8 +154,8 @@ class CoClustering(AlgoBase):
 
         return self
 
-    def compute_averages(self, np.ndarray[np.int_t] cltr_u,
-                         np.ndarray[np.int_t] cltr_i):
+    def compute_averages(self, np.ndarray[np.int64_t] cltr_u,
+                         np.ndarray[np.int64_t] cltr_i):
         """Compute cluster averages.
 
         Args:
@@ -168,14 +168,14 @@ class CoClustering(AlgoBase):
         """
 
         # Number of entities in user clusters, item clusters and co-clusters.
-        cdef np.ndarray[np.int_t] count_cltr_u
-        cdef np.ndarray[np.int_t] count_cltr_i
-        cdef np.ndarray[np.int_t, ndim=2] count_cocltr
+        cdef np.ndarray[np.int64_t] count_cltr_u
+        cdef np.ndarray[np.int64_t] count_cltr_i
+        cdef np.ndarray[np.int64_t, ndim=2] count_cocltr
 
         # Sum of ratings for entities in each cluster
-        cdef np.ndarray[np.int_t] sum_cltr_u
-        cdef np.ndarray[np.int_t] sum_cltr_i
-        cdef np.ndarray[np.int_t, ndim=2] sum_cocltr
+        cdef np.ndarray[np.int64_t] sum_cltr_u
+        cdef np.ndarray[np.int64_t] sum_cltr_i
+        cdef np.ndarray[np.int64_t, ndim=2] sum_cocltr
 
         # The averages of each cluster (what will be returned)
         cdef np.ndarray[np.double_t] avg_cltr_u


### PR DESCRIPTION
This change allows the package to be installed with Python >=3.13.2 by removing the deprecated datatype `int_t` and replacing it with the 64 bit integer type `int64_t`.