### PR TITLE
Enable numpy 2

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,7 +21,7 @@ license = { "file" = "LICENSE.md" }
 dependencies = [
   # Lower bounds for deps are as in scikit-learn in May 2024, 1.6.dev0
   "joblib>=1.2.0",
-  "numpy>=1.19.5",
+  "numpy>=2.0.0",
   "scipy>=1.6.0"
 ]
 dynamic = ["version", "readme"]
@@ -34,7 +34,7 @@ homepage = "https://surpriselib.com"
 repository = "https://github.com/NicolasHug/Surprise"
 
 [build-system]
-requires = ["setuptools>=61.0.0", "wheel", "Cython>=3.0.10", "oldest-supported-numpy"]
+requires = ["setuptools>=61.0.0", "wheel", "Cython>=3.0.10", "numpy>=2.0.0"]
 build-backend = "setuptools.build_meta"
 
 [tool.setuptools.dynamic]

--- a/surprise/prediction_algorithms/co_clustering.pyx
+++ b/surprise/prediction_algorithms/co_clustering.pyx
@@ -7,6 +7,7 @@ the :mod:`co_clustering` module includes the :class:`CoClustering` algorithm.
 
 cimport numpy as np  # noqa
 import numpy as np
+from libc.stdint cimport int64_t
 
 from .algo_base import AlgoBase
 from ..utils import get_rng
@@ -73,30 +74,30 @@ class CoClustering(AlgoBase):
         AlgoBase.fit(self, trainset)
 
         # User and item means
-        cdef np.ndarray[np.double_t] user_mean
-        cdef np.ndarray[np.double_t] item_mean
+        cdef np.ndarray[np.float64_t] user_mean
+        cdef np.ndarray[np.float64_t] item_mean
 
         # User and items clusters
-        cdef np.ndarray[np.int_t] cltr_u
-        cdef np.ndarray[np.int_t] cltr_i
+        cdef np.ndarray[np.int64_t] cltr_u
+        cdef np.ndarray[np.int64_t] cltr_i
 
         # Average rating of user clusters, item clusters and co-clusters
-        cdef np.ndarray[np.double_t] avg_cltr_u
-        cdef np.ndarray[np.double_t] avg_cltr_i
-        cdef np.ndarray[np.double_t, ndim=2] avg_cocltr
+        cdef np.ndarray[np.float64_t] avg_cltr_u
+        cdef np.ndarray[np.float64_t] avg_cltr_i
+        cdef np.ndarray[np.float64_t, ndim=2] avg_cocltr
 
-        cdef np.ndarray[np.double_t] errors
+        cdef np.ndarray[np.float64_t] errors
         cdef int u, i, r, uc, ic
         cdef double est
 
         # Randomly assign users and items to intial clusters
         rng = get_rng(self.random_state)
-        cltr_u = rng.randint(self.n_cltr_u, size=trainset.n_users)
-        cltr_i = rng.randint(self.n_cltr_i, size=trainset.n_items)
+        cltr_u = rng.randint(self.n_cltr_u, size=trainset.n_users, dtype=np.int64)
+        cltr_i = rng.randint(self.n_cltr_i, size=trainset.n_items, dtype=np.int64)
 
         # Compute user and item means
-        user_mean = np.zeros(self.trainset.n_users, np.double)
-        item_mean = np.zeros(self.trainset.n_items, np.double)
+        user_mean = np.zeros(self.trainset.n_users, dtype=np.float64)
+        item_mean = np.zeros(self.trainset.n_items, dtype=np.float64)
         for u in trainset.all_users():
             user_mean[u] = np.mean([r for (_, r) in trainset.ur[u]])
         for i in trainset.all_items():
@@ -115,7 +116,7 @@ class CoClustering(AlgoBase):
             # set user cluster to the one that minimizes squarred error of all
             # the user's ratings.
             for u in self.trainset.all_users():
-                errors = np.zeros(self.n_cltr_u, np.double)
+                errors = np.zeros(self.n_cltr_u, dtype=np.float64)
                 for uc in range(self.n_cltr_u):
                     for i, r in self.trainset.ur[u]:
                         ic = cltr_i[i]
@@ -128,7 +129,7 @@ class CoClustering(AlgoBase):
             # set item cluster to the one that minimizes squarred error over
             # all the item's ratings.
             for i in self.trainset.all_items():
-                errors = np.zeros(self.n_cltr_i, np.double)
+                errors = np.zeros(self.n_cltr_i, dtype=np.float64)
                 for ic in range(self.n_cltr_i):
                     for u, r in self.trainset.ir[i]:
                         uc = cltr_u[u]
@@ -154,8 +155,8 @@ class CoClustering(AlgoBase):
 
         return self
 
-    def compute_averages(self, np.ndarray[np.int_t] cltr_u,
-                         np.ndarray[np.int_t] cltr_i):
+    def compute_averages(self, np.ndarray[np.int64_t] cltr_u,
+                         np.ndarray[np.int64_t] cltr_i):
         """Compute cluster averages.
 
         Args:
@@ -168,35 +169,35 @@ class CoClustering(AlgoBase):
         """
 
         # Number of entities in user clusters, item clusters and co-clusters.
-        cdef np.ndarray[np.int_t] count_cltr_u
-        cdef np.ndarray[np.int_t] count_cltr_i
-        cdef np.ndarray[np.int_t, ndim=2] count_cocltr
+        cdef np.ndarray[np.int64_t] count_cltr_u
+        cdef np.ndarray[np.int64_t] count_cltr_i
+        cdef np.ndarray[np.int64_t, ndim=2] count_cocltr
 
         # Sum of ratings for entities in each cluster
-        cdef np.ndarray[np.int_t] sum_cltr_u
-        cdef np.ndarray[np.int_t] sum_cltr_i
-        cdef np.ndarray[np.int_t, ndim=2] sum_cocltr
+        cdef np.ndarray[np.int64_t] sum_cltr_u
+        cdef np.ndarray[np.int64_t] sum_cltr_i
+        cdef np.ndarray[np.int64_t, ndim=2] sum_cocltr
 
         # The averages of each cluster (what will be returned)
-        cdef np.ndarray[np.double_t] avg_cltr_u
-        cdef np.ndarray[np.double_t] avg_cltr_i
-        cdef np.ndarray[np.double_t, ndim=2] avg_cocltr
+        cdef np.ndarray[np.float64_t] avg_cltr_u
+        cdef np.ndarray[np.float64_t] avg_cltr_i
+        cdef np.ndarray[np.float64_t, ndim=2] avg_cocltr
 
         cdef int u, i, r, uc, ic
         cdef double global_mean = self.trainset.global_mean
 
         # Initialize everything to zero
-        count_cltr_u = np.zeros(self.n_cltr_u, np.int_)
-        count_cltr_i = np.zeros(self.n_cltr_i, np.int_)
-        count_cocltr = np.zeros((self.n_cltr_u, self.n_cltr_i), np.int_)
+        count_cltr_u = np.zeros(self.n_cltr_u, dtype=np.int64)
+        count_cltr_i = np.zeros(self.n_cltr_i, dtype=np.int64)
+        count_cocltr = np.zeros((self.n_cltr_u, self.n_cltr_i), dtype=np.int64)
 
-        sum_cltr_u = np.zeros(self.n_cltr_u, np.int_)
-        sum_cltr_i = np.zeros(self.n_cltr_i, np.int_)
-        sum_cocltr = np.zeros((self.n_cltr_u, self.n_cltr_i), np.int_)
+        sum_cltr_u = np.zeros(self.n_cltr_u, dtype=np.int64)
+        sum_cltr_i = np.zeros(self.n_cltr_i, dtype=np.int64)
+        sum_cocltr = np.zeros((self.n_cltr_u, self.n_cltr_i), dtype=np.int64)
 
-        avg_cltr_u = np.zeros(self.n_cltr_u, np.double)
-        avg_cltr_i = np.zeros(self.n_cltr_i, np.double)
-        avg_cocltr = np.zeros((self.n_cltr_u, self.n_cltr_i), np.double)
+        avg_cltr_u = np.zeros(self.n_cltr_u, dtype=np.float64)
+        avg_cltr_i = np.zeros(self.n_cltr_i, dtype=np.float64)
+        avg_cocltr = np.zeros((self.n_cltr_u, self.n_cltr_i), dtype=np.float64)
 
         # Compute counts and sums for every cluster.
         for u, i, r in self.trainset.all_ratings():

--- a/surprise/prediction_algorithms/matrix_factorization.pyx
+++ b/surprise/prediction_algorithms/matrix_factorization.pyx
@@ -193,9 +193,9 @@ class SVD(AlgoBase):
         rng = get_rng(self.random_state)
 
         # user biases
-        cdef double [::1] bu = np.zeros(trainset.n_users, dtype=np.double)
+        cdef double [::1] bu = np.zeros(trainset.n_users, dtype=np.float64)
         # item biases
-        cdef double [::1] bi = np.zeros(trainset.n_items, dtype=np.double)
+        cdef double [::1] bi = np.zeros(trainset.n_items, dtype=np.float64)
         # user factors
         cdef double [:, ::1] pu = rng.normal(self.init_mean, self.init_std_dev, size=(trainset.n_users, self.n_factors))
         # item factors
@@ -406,9 +406,9 @@ class SVDpp(AlgoBase):
         rng = get_rng(self.random_state)
 
         # user biases
-        cdef double [::1] bu = np.zeros(trainset.n_users, dtype=np.double)
+        cdef double [::1] bu = np.zeros(trainset.n_users, dtype=np.float64)
         # item biases
-        cdef double [::1] bi = np.zeros(trainset.n_items, dtype=np.double)
+        cdef double [::1] bi = np.zeros(trainset.n_items, dtype=np.float64)
         # user factors
         cdef double [:, ::1] pu = rng.normal(self.init_mean, self.init_std_dev, size=(trainset.n_users, self.n_factors))
         # item factors
@@ -416,7 +416,7 @@ class SVDpp(AlgoBase):
         # item implicit factors
         cdef double [:, ::1] yj = rng.normal(self.init_mean, self.init_std_dev, size=(trainset.n_items, self.n_factors))
 
-        cdef double [::1] u_impl_fdb = np.zeros(self.n_factors, dtype=np.double)
+        cdef double [::1] u_impl_fdb = np.zeros(self.n_factors, dtype=np.float64)
 
         cdef int u, i, j, f, k, Iu_length
         cdef int max_Iu_length = 0
@@ -668,8 +668,8 @@ class NMF(AlgoBase):
         cdef double [:, ::1] qi = rng.uniform(self.init_low, self.init_high, size=(trainset.n_items, self.n_factors))
 
         # user and item biases
-        cdef double [::1] bu = np.zeros(trainset.n_users, dtype=np.double)
-        cdef double [::1] bi = np.zeros(trainset.n_items, dtype=np.double)
+        cdef double [::1] bu = np.zeros(trainset.n_users, dtype=np.float64)
+        cdef double [::1] bi = np.zeros(trainset.n_items, dtype=np.float64)
 
         cdef int u, i, f
         cdef int n_factors = self.n_factors
@@ -683,10 +683,10 @@ class NMF(AlgoBase):
         cdef double global_mean = self.trainset.global_mean
 
         # auxiliary matrices used in optimization process
-        cdef double [:, ::1] user_num = np.zeros((trainset.n_users, n_factors))
-        cdef double [:, ::1] user_denom = np.zeros((trainset.n_users, n_factors))
-        cdef double [:, ::1] item_num = np.zeros((trainset.n_items, n_factors))
-        cdef double [:, ::1] item_denom = np.zeros((trainset.n_items, n_factors))
+        cdef double [:, ::1] user_num = np.zeros((trainset.n_users, n_factors), dtype=np.float64)
+        cdef double [:, ::1] user_denom = np.zeros((trainset.n_users, n_factors), dtype=np.float64)
+        cdef double [:, ::1] item_num = np.zeros((trainset.n_items, n_factors), dtype=np.float64)
+        cdef double [:, ::1] item_denom = np.zeros((trainset.n_items, n_factors), dtype=np.float64)
 
 
         if not self.biased:

--- a/surprise/prediction_algorithms/optimize_baselines.pyx
+++ b/surprise/prediction_algorithms/optimize_baselines.pyx
@@ -25,8 +25,8 @@ def baseline_als(self):
     # see also https://www.youtube.com/watch?v=gCaOa3W9kM0&t=32m55s
     # (Alex Smola on RS, ML Class 10-701)
 
-    cdef double [::1] bu = np.zeros(self.trainset.n_users)
-    cdef double [::1] bi = np.zeros(self.trainset.n_items)
+    cdef double [::1] bu = np.zeros(self.trainset.n_users, dtype=np.float64)
+    cdef double [::1] bi = np.zeros(self.trainset.n_items, dtype=np.float64)
 
     cdef int u, i
     cdef double r, err, dev_i, dev_u
@@ -63,8 +63,8 @@ def baseline_sgd(self):
         A tuple ``(bu, bi)``, which are users and items baselines.
     """
 
-    cdef double [::1] bu = np.zeros(self.trainset.n_users)
-    cdef double [::1] bi = np.zeros(self.trainset.n_items)
+    cdef double [::1] bu = np.zeros(self.trainset.n_users, dtype=np.float64)
+    cdef double [::1] bi = np.zeros(self.trainset.n_items, dtype=np.float64)
 
     cdef int u, i
     cdef double r, err

--- a/surprise/prediction_algorithms/slope_one.pyx
+++ b/surprise/prediction_algorithms/slope_one.pyx
@@ -7,6 +7,7 @@ the :mod:`slope_one` module includes the :class:`SlopeOne` algorithm.
 
 cimport numpy as np  # noqa
 import numpy as np
+from libc.stdint cimport int64_t
 
 from .algo_base import AlgoBase
 from .predictions import PredictionImpossible
@@ -44,9 +45,9 @@ class SlopeOne(AlgoBase):
         cdef int n_items = trainset.n_items
 
         # Number of users having rated items i and j: |U_ij|
-        cdef long [:, ::1] freq = np.zeros((trainset.n_items, trainset.n_items), np.int_)
+        cdef int64_t [:, ::1] freq = np.zeros((trainset.n_items, trainset.n_items), dtype=np.int64)
         # Deviation from item i to item j: mean(r_ui - r_uj for u in U_ij)
-        cdef double [:, ::1] dev = np.zeros((trainset.n_items, trainset.n_items), np.double)
+        cdef double [:, ::1] dev = np.zeros((trainset.n_items, trainset.n_items), dtype=np.float64)
         cdef int u, i, j, r_ui, r_uj
 
         AlgoBase.fit(self, trainset)

--- a/surprise/similarities.pyx
+++ b/surprise/similarities.pyx
@@ -19,6 +19,7 @@ Available similarity measures:
 cimport numpy as np  # noqa
 import numpy as np
 from libc.math cimport sqrt
+from libc.stdint cimport int64_t
 
 
 def cosine(int n_x, yr, int min_support):
@@ -51,15 +52,15 @@ def cosine(int n_x, yr, int min_support):
     """
 
     # sum (r_xy * r_x'y) for common ys
-    cdef double [:, ::1] prods = np.zeros((n_x, n_x), np.double)
+    cdef double [:, ::1] prods = np.zeros((n_x, n_x), dtype=np.float64)
     # number of common ys
-    cdef long [:, ::1] freq = np.zeros((n_x, n_x), np.int_)
+    cdef int64_t [:, ::1] freq = np.zeros((n_x, n_x), dtype=np.int64)
     # sum (r_xy ^ 2) for common ys
-    cdef double [:, ::1] sqi = np.zeros((n_x, n_x), np.double)
+    cdef double [:, ::1] sqi = np.zeros((n_x, n_x), dtype=np.float64)
     # sum (r_x'y ^ 2) for common ys
-    cdef double [:, ::1] sqj = np.zeros((n_x, n_x), np.double)
+    cdef double [:, ::1] sqj = np.zeros((n_x, n_x), dtype=np.float64)
     # the similarity matrix
-    cdef double [:, ::1] sim = np.zeros((n_x, n_x), np.double)
+    cdef double [:, ::1] sim = np.zeros((n_x, n_x), dtype=np.float64)
 
     cdef int xi, xj, y
     cdef double ri, rj
@@ -122,11 +123,11 @@ def msd(int n_x, yr, int min_support):
     """
 
     # sum (r_xy - r_x'y)**2 for common ys
-    cdef double [:, ::1] sq_diff = np.zeros((n_x, n_x), np.double)
+    cdef double [:, ::1] sq_diff = np.zeros((n_x, n_x), dtype=np.float64)
     # number of common ys
-    cdef long [:, ::1] freq = np.zeros((n_x, n_x), np.int_)
+    cdef int64_t [:, ::1] freq = np.zeros((n_x, n_x), dtype=np.int64)
     # the similarity matrix
-    cdef double [:, ::1] sim = np.zeros((n_x, n_x), np.double)
+    cdef double [:, ::1] sim = np.zeros((n_x, n_x), dtype=np.float64)
 
     cdef int xi, xj
     cdef double ri, rj
@@ -186,19 +187,19 @@ def pearson(int n_x, yr, int min_support):
 
     """
     # number of common ys
-    cdef long [:, ::1] freq = np.zeros((n_x, n_x), np.int_)
+    cdef int64_t [:, ::1] freq = np.zeros((n_x, n_x), dtype=np.int64)
     # sum (r_xy * r_x'y) for common ys
-    cdef double [:, ::1] prods = np.zeros((n_x, n_x), np.double)
+    cdef double [:, ::1] prods = np.zeros((n_x, n_x), dtype=np.float64)
     # sum (rxy ^ 2) for common ys
-    cdef double [:, ::1] sqi = np.zeros((n_x, n_x), np.double)
+    cdef double [:, ::1] sqi = np.zeros((n_x, n_x), dtype=np.float64)
     # sum (rx'y ^ 2) for common ys
-    cdef double [:, ::1] sqj = np.zeros((n_x, n_x), np.double)
+    cdef double [:, ::1] sqj = np.zeros((n_x, n_x), dtype=np.float64)
     # sum (rxy) for common ys
-    cdef double [:, ::1] si = np.zeros((n_x, n_x), np.double)
+    cdef double [:, ::1] si = np.zeros((n_x, n_x), dtype=np.float64)
     # sum (rx'y) for common ys
-    cdef double [:, ::1] sj = np.zeros((n_x, n_x), np.double)
+    cdef double [:, ::1] sj = np.zeros((n_x, n_x), dtype=np.float64)
     # the similarity matrix
-    cdef double [:, ::1] sim = np.zeros((n_x, n_x), np.double)
+    cdef double [:, ::1] sim = np.zeros((n_x, n_x), dtype=np.float64)
 
     cdef int xi, xj, y, n
     cdef double ri, rj, num, denum
@@ -286,15 +287,15 @@ def pearson_baseline(
     """
 
     # number of common ys
-    cdef long [:, ::1] freq = np.zeros((n_x, n_x), np.int_)
+    cdef int64_t [:, ::1] freq = np.zeros((n_x, n_x), dtype=np.int64)
     # sum (r_xy - b_xy) * (r_x'y - b_x'y) for common ys
-    cdef double [:, ::1] prods = np.zeros((n_x, n_x), np.double)
+    cdef double [:, ::1] prods = np.zeros((n_x, n_x), dtype=np.float64)
     # sum (r_xy - b_xy)**2 for common ys
-    cdef double [:, ::1] sq_diff_i = np.zeros((n_x, n_x), np.double)
+    cdef double [:, ::1] sq_diff_i = np.zeros((n_x, n_x), dtype=np.float64)
     # sum (r_x'y - b_x'y)**2 for common ys
-    cdef double [:, ::1] sq_diff_j = np.zeros((n_x, n_x), np.double)
+    cdef double [:, ::1] sq_diff_j = np.zeros((n_x, n_x), dtype=np.float64)
     # the similarity matrix
-    cdef double [:, ::1] sim = np.zeros((n_x, n_x), np.double)
+    cdef double [:, ::1] sim = np.zeros((n_x, n_x), dtype=np.float64)
 
     cdef int y, xi, xj
     cdef double ri, rj, diff_i, diff_j, partial_bias


### PR DESCRIPTION
This pull request updates the codebase to be compatible with NumPy 2.0, addressing the removal of deprecated NumPy aliases.

## Main Changes
  - Replaced deprecated np.double with np.float64 across all Cython files
  - Updated Cython type declarations from np.double_t to np.float64_t (both changes follow [NEP 52](https://numpy.org/neps/nep-0052-python-api-cleanup.html#reducing-the-number-of-ways-to-select-dtypes))
  - Standardized dtype parameters in np.zeros() calls for consistency
  - Used np.int64_t consistently for integer arrays (as previously proposed in #487)
  - Replaced long with int64_t from libc.stdint for cross-platform compatibility

## Other info.
  - No changes to algorithm logic or performance characteristics
  - All existing tests continue to pass
 