### PR TITLE
Fix numpy 2 compatibility? Who knows!

### DIFF
--- a/.github/workflows/benchmarks.yml
+++ b/.github/workflows/benchmarks.yml
@@ -16,7 +16,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["3.9"]
+        python-version: ["3.12"]
 
     steps:
     - uses: actions/checkout@v4

--- a/.github/workflows/build_docs.yml
+++ b/.github/workflows/build_docs.yml
@@ -16,7 +16,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["3.9"]
+        python-version: ["3.12"]
 
     steps:
     - uses: actions/checkout@v4

--- a/.github/workflows/build_docs.yml
+++ b/.github/workflows/build_docs.yml
@@ -27,6 +27,7 @@ jobs:
     - name: Install Surprise with docs dependencies
       run: |
         pip install --upgrade pip
+        pip install -e .
         cd doc
         pip install -r requirements.txt
     - name: Build docs

--- a/.github/workflows/build_sdist.yml
+++ b/.github/workflows/build_sdist.yml
@@ -1,4 +1,4 @@
-# This workflow builds the sdist on 3.8 and then installs that same sdist on
+# This workflow builds the sdist on 3.10 and then installs that same sdist on
 
 name: Create sdist install and test
 
@@ -17,10 +17,10 @@ jobs:
 
     steps:
     - uses: actions/checkout@v4
-    - name: Set up Python 3.8
+    - name: Set up Python 3.10
       uses: actions/setup-python@v5
       with:
-        python-version: "3.8"
+        python-version: "3.10"
 
     - name: Build sdist
       run: |
@@ -38,11 +38,17 @@ jobs:
 
   install-and-test:
 
-    runs-on: ubuntu-latest
+    runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["3.8", "3.9", "3.10", "3.11", "3.12"]
+        os: [ubuntu-latest]
+        python-version: ["3.10", "3.11", "3.12", "3.13", "3.14", "3.13t", "3.14t"]
+        include:
+          - os: macos-latest
+            python-version: "3.10"
+          - os: windows-latest
+            python-version: "3.10"
     needs: build
     steps:
     - uses: actions/checkout@v4
@@ -56,12 +62,19 @@ jobs:
       with:
         python-version: ${{ matrix.python-version }}
 
-    - name: Install sdist
+    - name: Install sdist (Unix)
+      if: runner.os != 'Windows'
       run: |
         set -x
 
         pip install --upgrade pip
-        pip install dist/scikit_surprise-1.1.4.tar.gz -v
+        pip install dist/scikit_surprise-*.tar.gz -v
+
+    - name: Install sdist (Windows)
+      if: runner.os == 'Windows'
+      run: |
+        pip install --upgrade pip
+        pip install (Get-ChildItem dist/scikit_surprise-*.tar.gz).FullName -v
 
     - name: Pip freeze
       run: |

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -15,7 +15,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["3.9"]
+        python-version: ["3.10"]
 
     steps:
     - uses: actions/checkout@v4

--- a/.github/workflows/min_deps.yml
+++ b/.github/workflows/min_deps.yml
@@ -1,0 +1,39 @@
+name: Minimum dependency versions
+
+on:
+  push:
+    branches: [ "master" ]
+  pull_request:
+    branches: [ "master" ]
+
+jobs:
+  min-deps:
+
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+
+    steps:
+    - uses: actions/checkout@v4
+    - name: Set up Python 3.10
+      uses: actions/setup-python@v5
+      with:
+        python-version: "3.10"
+
+    - name: Install with minimum dependency versions
+      run: |
+        set -x
+        pip install --upgrade pip
+        pip install -e .
+        pip install joblib==1.4.0 numpy==1.24.1 scipy==1.10.0
+        pip install pandas pytest
+
+    - name: Verify pinned versions
+      run: |
+        python -c "import joblib; assert joblib.__version__ == '1.4.0'"
+        python -c "import numpy; assert numpy.__version__ == '1.24.1'"
+        python -c "import scipy; assert scipy.__version__ == '1.10.0'"
+
+    - name: Run unit tests
+      run: |
+        pytest -v

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,11 @@
+VERSION 1.1.5
+=============
+
+Date: 05/2026
+
+* Fix numpy 2 support issues
+* Support 3.10 from 3.14, with 3.13t and 3.14t
+
 VERSION 1.1.4
 =============
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -2,7 +2,7 @@
 name = "scikit-surprise"
 authors = [{ name = "Nicolas Hug", email = "contact@nicolas-hug.com" }]
 description = "An easy-to-use library for recommender systems."
-requires-python = ">=3.8"
+requires-python = ">=3.10"
 keywords = [ "recommender", "recommendation system" ]
 classifiers = [
   "Development Status :: 5 - Production/Stable",
@@ -11,18 +11,18 @@ classifiers = [
   "Intended Audience :: Science/Research",
   "Topic :: Scientific/Engineering",
   "License :: OSI Approved :: BSD License",
-  "Programming Language :: Python :: 3.8",
-  "Programming Language :: Python :: 3.9",
   "Programming Language :: Python :: 3.10",
   "Programming Language :: Python :: 3.11",
   "Programming Language :: Python :: 3.12",
+  "Programming Language :: Python :: 3.13",
+  "Programming Language :: Python :: 3.14",
 ]
 license = { "file" = "LICENSE.md" }
 dependencies = [
-  # Lower bounds for deps are as in scikit-learn in May 2024, 1.6.dev0
-  "joblib>=1.2.0",
-  "numpy>=1.19.5",
-  "scipy>=1.6.0"
+  # Lower bounds are aligned with scikit-learn's as of May 2026
+  "joblib>=1.4.0",
+  "numpy>=1.24.1",
+  "scipy>=1.10.0"
 ]
 dynamic = ["version", "readme"]
 
@@ -34,7 +34,9 @@ homepage = "https://surpriselib.com"
 repository = "https://github.com/NicolasHug/Surprise"
 
 [build-system]
-requires = ["setuptools>=61.0.0", "wheel", "Cython>=3.0.10", "oldest-supported-numpy"]
+# Note: We build with numpy 2 but the resulting wheel (source or not) should still be
+# compatible with numpy < 2
+requires = ["setuptools>=61.0.0", "wheel", "Cython>=3.1.0", "numpy>=2"]
 build-backend = "setuptools.build_meta"
 
 [tool.setuptools.dynamic]

--- a/setup.py
+++ b/setup.py
@@ -26,8 +26,7 @@ Basic local checks:
 
 Check that the latest RTD build was OK: https://readthedocs.org/projects/surprise/builds/
 
-Change __version__ in __init__.py to new version name. Also update the hardcoded
-version in build_sdist.yml, otherwise the GA jobs will fail.
+Change __version__ in __init__.py to new version name.
 
 The sdist is built on Python 3.8. It should be installable from all Python
 versions.

--- a/surprise/__init__.py
+++ b/surprise/__init__.py
@@ -45,4 +45,4 @@ __all__ = [
     "model_selection",
 ]
 
-__version__ = "1.1.4"
+__version__ = "1.1.5"

--- a/surprise/prediction_algorithms/co_clustering.pyx
+++ b/surprise/prediction_algorithms/co_clustering.pyx
@@ -91,8 +91,8 @@ class CoClustering(AlgoBase):
 
         # Randomly assign users and items to intial clusters
         rng = get_rng(self.random_state)
-        cltr_u = rng.randint(self.n_cltr_u, size=trainset.n_users)
-        cltr_i = rng.randint(self.n_cltr_i, size=trainset.n_items)
+        cltr_u = rng.randint(self.n_cltr_u, size=trainset.n_users).astype(np.intp)
+        cltr_i = rng.randint(self.n_cltr_i, size=trainset.n_items).astype(np.intp)
 
         # Compute user and item means
         user_mean = np.zeros(self.trainset.n_users, np.double)

--- a/surprise/prediction_algorithms/co_clustering.pyx
+++ b/surprise/prediction_algorithms/co_clustering.pyx
@@ -77,8 +77,8 @@ class CoClustering(AlgoBase):
         cdef np.ndarray[np.double_t] item_mean
 
         # User and items clusters
-        cdef np.ndarray[np.int_t] cltr_u
-        cdef np.ndarray[np.int_t] cltr_i
+        cdef np.ndarray[np.intp_t] cltr_u
+        cdef np.ndarray[np.intp_t] cltr_i
 
         # Average rating of user clusters, item clusters and co-clusters
         cdef np.ndarray[np.double_t] avg_cltr_u
@@ -154,8 +154,8 @@ class CoClustering(AlgoBase):
 
         return self
 
-    def compute_averages(self, np.ndarray[np.int_t] cltr_u,
-                         np.ndarray[np.int_t] cltr_i):
+    def compute_averages(self, np.ndarray[np.intp_t] cltr_u,
+                         np.ndarray[np.intp_t] cltr_i):
         """Compute cluster averages.
 
         Args:
@@ -168,14 +168,14 @@ class CoClustering(AlgoBase):
         """
 
         # Number of entities in user clusters, item clusters and co-clusters.
-        cdef np.ndarray[np.int_t] count_cltr_u
-        cdef np.ndarray[np.int_t] count_cltr_i
-        cdef np.ndarray[np.int_t, ndim=2] count_cocltr
+        cdef np.ndarray[np.intp_t] count_cltr_u
+        cdef np.ndarray[np.intp_t] count_cltr_i
+        cdef np.ndarray[np.intp_t, ndim=2] count_cocltr
 
         # Sum of ratings for entities in each cluster
-        cdef np.ndarray[np.int_t] sum_cltr_u
-        cdef np.ndarray[np.int_t] sum_cltr_i
-        cdef np.ndarray[np.int_t, ndim=2] sum_cocltr
+        cdef np.ndarray[np.intp_t] sum_cltr_u
+        cdef np.ndarray[np.intp_t] sum_cltr_i
+        cdef np.ndarray[np.intp_t, ndim=2] sum_cocltr
 
         # The averages of each cluster (what will be returned)
         cdef np.ndarray[np.double_t] avg_cltr_u
@@ -186,13 +186,13 @@ class CoClustering(AlgoBase):
         cdef double global_mean = self.trainset.global_mean
 
         # Initialize everything to zero
-        count_cltr_u = np.zeros(self.n_cltr_u, np.int_)
-        count_cltr_i = np.zeros(self.n_cltr_i, np.int_)
-        count_cocltr = np.zeros((self.n_cltr_u, self.n_cltr_i), np.int_)
+        count_cltr_u = np.zeros(self.n_cltr_u, np.intp)
+        count_cltr_i = np.zeros(self.n_cltr_i, np.intp)
+        count_cocltr = np.zeros((self.n_cltr_u, self.n_cltr_i), np.intp)
 
-        sum_cltr_u = np.zeros(self.n_cltr_u, np.int_)
-        sum_cltr_i = np.zeros(self.n_cltr_i, np.int_)
-        sum_cocltr = np.zeros((self.n_cltr_u, self.n_cltr_i), np.int_)
+        sum_cltr_u = np.zeros(self.n_cltr_u, np.intp)
+        sum_cltr_i = np.zeros(self.n_cltr_i, np.intp)
+        sum_cocltr = np.zeros((self.n_cltr_u, self.n_cltr_i), np.intp)
 
         avg_cltr_u = np.zeros(self.n_cltr_u, np.double)
         avg_cltr_i = np.zeros(self.n_cltr_i, np.double)

--- a/surprise/prediction_algorithms/slope_one.pyx
+++ b/surprise/prediction_algorithms/slope_one.pyx
@@ -44,7 +44,7 @@ class SlopeOne(AlgoBase):
         cdef int n_items = trainset.n_items
 
         # Number of users having rated items i and j: |U_ij|
-        cdef long [:, ::1] freq = np.zeros((trainset.n_items, trainset.n_items), np.int_)
+        cdef long [:, ::1] freq = np.zeros((trainset.n_items, trainset.n_items), np.intp)
         # Deviation from item i to item j: mean(r_ui - r_uj for u in U_ij)
         cdef double [:, ::1] dev = np.zeros((trainset.n_items, trainset.n_items), np.double)
         cdef int u, i, j, r_ui, r_uj

--- a/surprise/prediction_algorithms/slope_one.pyx
+++ b/surprise/prediction_algorithms/slope_one.pyx
@@ -44,7 +44,7 @@ class SlopeOne(AlgoBase):
         cdef int n_items = trainset.n_items
 
         # Number of users having rated items i and j: |U_ij|
-        cdef long [:, ::1] freq = np.zeros((trainset.n_items, trainset.n_items), np.intp)
+        cdef Py_ssize_t [:, ::1] freq = np.zeros((trainset.n_items, trainset.n_items), np.intp)
         # Deviation from item i to item j: mean(r_ui - r_uj for u in U_ij)
         cdef double [:, ::1] dev = np.zeros((trainset.n_items, trainset.n_items), np.double)
         cdef int u, i, j, r_ui, r_uj

--- a/surprise/similarities.pyx
+++ b/surprise/similarities.pyx
@@ -53,7 +53,7 @@ def cosine(int n_x, yr, int min_support):
     # sum (r_xy * r_x'y) for common ys
     cdef double [:, ::1] prods = np.zeros((n_x, n_x), np.double)
     # number of common ys
-    cdef long [:, ::1] freq = np.zeros((n_x, n_x), np.int_)
+    cdef long [:, ::1] freq = np.zeros((n_x, n_x), np.intp)
     # sum (r_xy ^ 2) for common ys
     cdef double [:, ::1] sqi = np.zeros((n_x, n_x), np.double)
     # sum (r_x'y ^ 2) for common ys
@@ -124,7 +124,7 @@ def msd(int n_x, yr, int min_support):
     # sum (r_xy - r_x'y)**2 for common ys
     cdef double [:, ::1] sq_diff = np.zeros((n_x, n_x), np.double)
     # number of common ys
-    cdef long [:, ::1] freq = np.zeros((n_x, n_x), np.int_)
+    cdef long [:, ::1] freq = np.zeros((n_x, n_x), np.intp)
     # the similarity matrix
     cdef double [:, ::1] sim = np.zeros((n_x, n_x), np.double)
 
@@ -186,7 +186,7 @@ def pearson(int n_x, yr, int min_support):
 
     """
     # number of common ys
-    cdef long [:, ::1] freq = np.zeros((n_x, n_x), np.int_)
+    cdef long [:, ::1] freq = np.zeros((n_x, n_x), np.intp)
     # sum (r_xy * r_x'y) for common ys
     cdef double [:, ::1] prods = np.zeros((n_x, n_x), np.double)
     # sum (rxy ^ 2) for common ys
@@ -286,7 +286,7 @@ def pearson_baseline(
     """
 
     # number of common ys
-    cdef long [:, ::1] freq = np.zeros((n_x, n_x), np.int_)
+    cdef long [:, ::1] freq = np.zeros((n_x, n_x), np.intp)
     # sum (r_xy - b_xy) * (r_x'y - b_x'y) for common ys
     cdef double [:, ::1] prods = np.zeros((n_x, n_x), np.double)
     # sum (r_xy - b_xy)**2 for common ys

--- a/surprise/similarities.pyx
+++ b/surprise/similarities.pyx
@@ -53,7 +53,7 @@ def cosine(int n_x, yr, int min_support):
     # sum (r_xy * r_x'y) for common ys
     cdef double [:, ::1] prods = np.zeros((n_x, n_x), np.double)
     # number of common ys
-    cdef long [:, ::1] freq = np.zeros((n_x, n_x), np.intp)
+    cdef Py_ssize_t [:, ::1] freq = np.zeros((n_x, n_x), np.intp)
     # sum (r_xy ^ 2) for common ys
     cdef double [:, ::1] sqi = np.zeros((n_x, n_x), np.double)
     # sum (r_x'y ^ 2) for common ys
@@ -124,7 +124,7 @@ def msd(int n_x, yr, int min_support):
     # sum (r_xy - r_x'y)**2 for common ys
     cdef double [:, ::1] sq_diff = np.zeros((n_x, n_x), np.double)
     # number of common ys
-    cdef long [:, ::1] freq = np.zeros((n_x, n_x), np.intp)
+    cdef Py_ssize_t [:, ::1] freq = np.zeros((n_x, n_x), np.intp)
     # the similarity matrix
     cdef double [:, ::1] sim = np.zeros((n_x, n_x), np.double)
 
@@ -186,7 +186,7 @@ def pearson(int n_x, yr, int min_support):
 
     """
     # number of common ys
-    cdef long [:, ::1] freq = np.zeros((n_x, n_x), np.intp)
+    cdef Py_ssize_t [:, ::1] freq = np.zeros((n_x, n_x), np.intp)
     # sum (r_xy * r_x'y) for common ys
     cdef double [:, ::1] prods = np.zeros((n_x, n_x), np.double)
     # sum (rxy ^ 2) for common ys
@@ -286,7 +286,7 @@ def pearson_baseline(
     """
 
     # number of common ys
-    cdef long [:, ::1] freq = np.zeros((n_x, n_x), np.intp)
+    cdef Py_ssize_t [:, ::1] freq = np.zeros((n_x, n_x), np.intp)
     # sum (r_xy - b_xy) * (r_x'y - b_x'y) for common ys
     cdef double [:, ::1] prods = np.zeros((n_x, n_x), np.double)
     # sum (r_xy - b_xy)**2 for common ys

--- a/tests/test_dump.py
+++ b/tests/test_dump.py
@@ -1,6 +1,7 @@
 """Module for testing the dump module."""
 
 
+import os
 import random
 import tempfile
 
@@ -49,28 +50,40 @@ def test_dump(algo, u1_ml100k):
 
     trainset, testset = next(PredefinedKFold().split(u1_ml100k))
 
-    with tempfile.NamedTemporaryFile() as tmp_file:
-        dump.dump(tmp_file.name, algo=algo)
-        dump.load(tmp_file.name)
+    fd, tmp_path = tempfile.mkstemp()
+    os.close(fd)
+    try:
+        dump.dump(tmp_path, algo=algo)
+        dump.load(tmp_path)
+    finally:
+        os.remove(tmp_path)
 
     algo.fit(trainset)
     predictions = algo.test(testset)
 
-    with tempfile.NamedTemporaryFile() as tmp_file:
-        dump.dump(tmp_file.name, predictions, algo)
-        predictions_dumped, algo_dumped = dump.load(tmp_file.name)
+    fd, tmp_path = tempfile.mkstemp()
+    os.close(fd)
+    try:
+        dump.dump(tmp_path, predictions, algo)
+        predictions_dumped, algo_dumped = dump.load(tmp_path)
 
         assert predictions == predictions_dumped
 
         predictions_algo_dumped = algo_dumped.test(testset)
         if not isinstance(algo, NormalPredictor):  # predictions are random
             assert predictions == predictions_algo_dumped
+    finally:
+        os.remove(tmp_path)
 
 
 def test_dump_nothing():
     """Ensure that by default None objects are dumped."""
-    with tempfile.NamedTemporaryFile() as tmp_file:
-        dump.dump(tmp_file.name)
-        predictions, algo = dump.load(tmp_file.name)
+    fd, tmp_path = tempfile.mkstemp()
+    os.close(fd)
+    try:
+        dump.dump(tmp_path)
+        predictions, algo = dump.load(tmp_path)
         assert predictions is None
         assert algo is None
+    finally:
+        os.remove(tmp_path)


### PR DESCRIPTION
With claude.

- Fix compat with numpy 2:
  - Build on numpy 2
  - Should still be compatible with numpy < 2, upgraded the lower bound  for runtime numpy and scipy based on that of scikit-learn
- Update test matrix to have 3.10 to 3.14 along with 3.13t and 3.14t. 
- Fix doc build job
- Added basic MacOS and Windows unittest jobs